### PR TITLE
Allow late move pruning on pv nodes

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -362,7 +362,7 @@ impl Engine {
             let lmr = match self.lmr(draft, n) {
                 #[cfg(not(test))]
                 // The late move reduction heuristic is not exact.
-                r @ 1.. if !is_pv => r,
+                r @ 1.. => r - (is_pv as i8),
                 _ => 0,
             };
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -56       5    9000    1846    3278    3876   3784.0   42.0%   43.1% 
   1 Blackmarlin-9.0               107      10    3000    1320     422    1258   1949.0   65.0%   41.9% 
   2 Renegade-1.1.0                 63       9    3000    1126     591    1283   1767.5   58.9%   42.8% 
   3 Halogen-12.0                   -0       9    3000     832     833    1335   1499.5   50.0%   44.5%
```

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Pawn-3.0 -engine conf=Halogen-12.0 -engine conf=Willow-4.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            23       5    9000    2797    2194    4009   4801.5   53.3%   44.5% 
   1 Halogen-12.0                    2       9    3000     849     829    1322   1510.0   50.3%   44.1% 
   2 Pawn-3.0                      -34       9    3000     656     948    1396   1354.0   45.1%   46.5% 
   3 Willow-4.0                    -38       9    3000     689    1020    1291   1334.5   44.5%   43.0%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```

```