### PR TITLE
Centralize logic to normalize score to ply

### DIFF
--- a/lib/search/history.rs
+++ b/lib/search/history.rs
@@ -1,12 +1,14 @@
 use crate::chess::{Color, Move};
 use crate::util::Assume;
-use std::array;
+use derive_more::Debug;
 use std::sync::atomic::{AtomicI8, Ordering::Relaxed};
+use std::{array, mem::size_of};
 
 /// [Historical statistics] about a [`Move`].
 ///
 /// [Historical statistics]: https://www.chessprogramming.org/History_Heuristic
 #[derive(Debug)]
+#[debug("History({})", size_of::<Self>())]
 pub struct History([[[AtomicI8; 2]; 64]; 64]);
 
 impl Default for History {
@@ -41,6 +43,7 @@ impl History {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt::Debug;
     use test_strategy::proptest;
 
     #[proptest]

--- a/lib/search/killers.rs
+++ b/lib/search/killers.rs
@@ -1,8 +1,9 @@
 use crate::chess::{Color, Move};
 use crate::search::Ply;
 use crate::util::{Assume, Binary, Bits, Integer};
-use std::array;
+use derive_more::Debug;
 use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
+use std::{array, mem::size_of};
 
 /// A pair of [killer moves].
 ///
@@ -29,7 +30,7 @@ impl Killer {
 }
 
 impl Binary for Killer {
-    type Bits = Bits<u32, 32>;
+    type Bits = Bits<u32, { 2 * <Option<Move> as Binary>::Bits::BITS }>;
 
     #[inline(always)]
     fn encode(&self) -> Self::Bits {
@@ -49,6 +50,7 @@ impl Binary for Killer {
 ///
 /// [killer moves]: https://www.chessprogramming.org/Killer_Move
 #[derive(Debug)]
+#[debug("Killers({})", size_of::<Self>())]
 pub struct Killers([[AtomicU32; 2]; Ply::MAX as usize]);
 
 impl Default for Killers {
@@ -82,6 +84,7 @@ mod tests {
     use crate::util::Integer;
     use proptest::sample::size_range;
     use std::collections::HashSet;
+    use std::fmt::Debug;
     use test_strategy::proptest;
 
     #[proptest]

--- a/lib/search/ply.rs
+++ b/lib/search/ply.rs
@@ -14,7 +14,7 @@ unsafe impl Integer for PlyRepr {
     const MAX: Self::Repr = 95;
 
     #[cfg(test)]
-    const MAX: Self::Repr = 3;
+    const MAX: Self::Repr = 7;
 }
 
 /// The number of half-moves played.

--- a/lib/util/bits.rs
+++ b/lib/util/bits.rs
@@ -41,6 +41,12 @@ unsafe impl<T: Unsigned + Primitive, const W: u32> Integer for Bits<T, W> {
 }
 
 impl<T: Unsigned, const W: u32> Bits<T, W> {
+    /// The bit width.
+    pub const BITS: u32 = const {
+        assert!(size_of::<T>() * 8 >= W as usize);
+        W
+    };
+
     /// Returns a slice of bits.
     #[inline(always)]
     pub fn slice<R: RangeBounds<u32>>(&self, r: R) -> Self {

--- a/lib/util/integer.rs
+++ b/lib/util/integer.rs
@@ -1,6 +1,6 @@
 use crate::util::Assume;
 use std::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
-use std::{mem::transmute_copy, ops::*};
+use std::{hint::unreachable_unchecked, mem::transmute_copy, ops::*};
 
 /// Trait for types that can be represented by a contiguous range of primitive integers.
 ///
@@ -30,6 +30,7 @@ pub unsafe trait Integer: Copy {
     }
 
     /// Casts from [`Integer::Repr`].
+    #[track_caller]
     #[inline(always)]
     fn new(i: Self::Repr) -> Self {
         (Self::MIN..=Self::MAX).contains(&i).assume();
@@ -171,7 +172,7 @@ macro_rules! impl_primitive_for {
                         32 => (self as i32).cast(),
                         64 => (self as i64).cast(),
                         128 => (self as i128).cast(),
-                        _ => unsafe { std::hint::unreachable_unchecked() },
+                        _ => unsafe { unreachable_unchecked() },
                     }
                 }
             }


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -53       5    9000    1883    3240    3877   3821.5   42.5%   43.1% 
   1 Blackmarlin-9.0                96      10    3000    1276     464    1260   1906.0   63.5%   42.0% 
   2 Renegade-1.1.0                 64      10    3000    1146     600    1254   1773.0   59.1%   41.8% 
   3 Halogen-12.0                   -0       9    3000     818     819    1363   1499.5   50.0%   45.4%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     69     63     70     72     69     57     61     58     48     62     52     57     62     60     46    906
   Score   7763   7360   8029   8472   7868   7600   7346   7172   6161   7395   6491   6882   6943   7134   6623 109239
Score(%)   91.3   92.0   93.4   95.2   92.6   95.0   89.6   89.7   86.8   93.6   92.7   93.0   92.6   90.3   90.7   92.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 04, 95.2%, "Square Vacancy"
2. STS 06, 95.0%, "Re-Capturing"
3. STS 10, 93.6%, "Simplification"
4. STS 03, 93.4%, "Knight Outposts"
5. STS 12, 93.0%, "Center Control"

:: Top 5 STS with low result ::
1. STS 09, 86.8%, "Advancement of a/b/c Pawns"
2. STS 07, 89.6%, "Offer of Simplification"
3. STS 08, 89.7%, "Advancement of f/g/h Pawns"
4. STS 14, 90.3%, "Queens and Rooks to the 7th rank"
5. STS 15, 90.7%, "Avoid Pointless Exchange"
```