### PR TITLE
Simplify futility pruning

### DIFF
--- a/lib/search/score.rs
+++ b/lib/search/score.rs
@@ -95,11 +95,6 @@ mod tests {
     }
 
     #[proptest]
-    fn normalize_preserves_mate_score(s: Score, p: Ply) {
-        assert_eq!(s.normalize(p).mate().is_some(), s.mate().is_some());
-    }
-
-    #[proptest]
     fn mate_returns_plies_to_mate(p: Ply) {
         if p > 0 {
             assert_eq!(Score::upper().normalize(p).mate(), Some(p));


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -42       5    9000    1971    3046    3983   3962.5   44.0%   44.3% 
   1 Blackmarlin-9.0                88      10    3000    1249     508    1243   1870.5   62.4%   41.4% 
   2 Renegade-1.1.0                 54       9    3000    1069     610    1321   1729.5   57.6%   44.0% 
   3 Halogen-12.0                  -14       9    3000     728     853    1419   1437.5   47.9%   47.3%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:29s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     72     58     64     65     70     55     59     51     47     60     53     56     60     56     46    872
   Score   7957   7097   7689   8087   7881   7612   7266   6636   6111   7295   6508   6893   6841   6972   6474 107319
Score(%)   93.6   88.7   89.4   90.9   92.7   95.2   88.6   83.0   86.1   92.3   93.0   93.1   91.2   88.3   88.7   90.3

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.2%, "Re-Capturing"
2. STS 01, 93.6%, "Undermining"
3. STS 12, 93.1%, "Center Control"
4. STS 11, 93.0%, "Activity of the King"
5. STS 05, 92.7%, "Bishop vs Knight"

:: Top 5 STS with low result ::
1. STS 08, 83.0%, "Advancement of f/g/h Pawns"
2. STS 09, 86.1%, "Advancement of a/b/c Pawns"
3. STS 14, 88.3%, "Queens and Rooks to the 7th rank"
4. STS 07, 88.6%, "Offer of Simplification"
5. STS 15, 88.7%, "Avoid Pointless Exchange"
```