### PR TITLE
Optimize algorithm to estimate move value

### DIFF
--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -4,8 +4,7 @@ use arrayvec::{ArrayVec, CapacityError};
 use derive_more::{Debug, Display, Error, From};
 use std::fmt::{self, Formatter};
 use std::hash::{Hash, Hasher};
-use std::num::NonZeroU32;
-use std::str::FromStr;
+use std::{num::NonZeroU32, ops::Index, str::FromStr};
 
 #[cfg(test)]
 use proptest::{prelude::*, sample::*};
@@ -652,6 +651,30 @@ impl Position {
     }
 }
 
+/// Retrieves the [`Piece`] at a given [`Square`], if any.
+impl Index<Square> for Position {
+    type Output = Option<Piece>;
+
+    #[inline(always)]
+    fn index(&self, sq: Square) -> &Self::Output {
+        match self.board.piece_on(sq) {
+            Some(Piece::WhitePawn) => &Some(Piece::WhitePawn),
+            Some(Piece::WhiteKnight) => &Some(Piece::WhiteKnight),
+            Some(Piece::WhiteBishop) => &Some(Piece::WhiteBishop),
+            Some(Piece::WhiteRook) => &Some(Piece::WhiteRook),
+            Some(Piece::WhiteQueen) => &Some(Piece::WhiteQueen),
+            Some(Piece::WhiteKing) => &Some(Piece::WhiteKing),
+            Some(Piece::BlackPawn) => &Some(Piece::BlackPawn),
+            Some(Piece::BlackKnight) => &Some(Piece::BlackKnight),
+            Some(Piece::BlackBishop) => &Some(Piece::BlackBishop),
+            Some(Piece::BlackRook) => &Some(Piece::BlackRook),
+            Some(Piece::BlackQueen) => &Some(Piece::BlackQueen),
+            Some(Piece::BlackKing) => &Some(Piece::BlackKing),
+            None => &None,
+        }
+    }
+}
+
 impl Display for Position {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.board, f)
@@ -736,7 +759,7 @@ mod tests {
     #[proptest]
     fn occupied_returns_non_empty_squares(pos: Position) {
         for sq in pos.occupied() {
-            assert_ne!(pos.board[sq], None);
+            assert_ne!(pos[sq], None);
         }
     }
 
@@ -747,7 +770,7 @@ mod tests {
 
     #[proptest]
     fn king_returns_square_occupied_by_a_king(pos: Position, c: Color) {
-        assert_eq!(pos.board[pos.king(c)], Some(Piece::new(Role::King, c)));
+        assert_eq!(pos[pos.king(c)], Some(Piece::new(Role::King, c)));
     }
 
     #[proptest]
@@ -832,12 +855,12 @@ mod tests {
         assert_ne!(pos, prev);
         assert_ne!(pos.turn(), prev.turn());
 
-        assert_eq!(pos.board[m.whence()], None);
+        assert_eq!(pos[m.whence()], None);
         assert_eq!(
-            pos.board[m.whither()],
+            pos[m.whither()],
             m.promotion()
                 .map(|r| Piece::new(r, prev.turn()))
-                .or_else(|| prev.board[m.whence()])
+                .or_else(|| prev[m.whence()])
         );
 
         assert_eq!(

--- a/lib/nnue.rs
+++ b/lib/nnue.rs
@@ -27,8 +27,8 @@ pub use value::*;
 /// [NNUE]: https://www.chessprogramming.org/NNUE
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 struct Nnue {
-    ft: Transformer<i16, { Positional::LEN }>,
-    psqt: Transformer<i32, { Material::LEN }>,
+    ft: Affine<i16, { Positional::LEN }>,
+    psqt: Linear<i32, { Material::LEN }>,
     hidden: [Hidden<{ Positional::LEN }>; Material::LEN],
 }
 
@@ -74,12 +74,12 @@ impl Nnue {
     }
 
     #[inline(always)]
-    fn psqt() -> &'static Transformer<i32, { Material::LEN }> {
+    fn psqt() -> &'static Linear<i32, { Material::LEN }> {
         unsafe { &NNUE.get().as_ref_unchecked().psqt }
     }
 
     #[inline(always)]
-    fn ft() -> &'static Transformer<i16, { Positional::LEN }> {
+    fn ft() -> &'static Affine<i16, { Positional::LEN }> {
         unsafe { &NNUE.get().as_ref_unchecked().ft }
     }
 

--- a/lib/search/driver.rs
+++ b/lib/search/driver.rs
@@ -102,7 +102,6 @@ impl Driver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{chess::Move, nnue::Value};
     use test_strategy::proptest;
 
     #[proptest]

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -271,15 +271,12 @@ impl Engine {
             .map(|m| {
                 if Some(m) == transposed.moves().next() {
                     (m, Value::upper())
+                } else if !m.is_quiet() {
+                    (m, pos.gain(m))
                 } else if killers.contains(m) {
                     (m, Value::new(25))
-                } else if m.is_quiet() {
-                    (m, Value::lower() / 2 + self.history.get(m, pos.turn()))
                 } else {
-                    let mut next = pos.material();
-                    let material = next.evaluate();
-                    next.play(m);
-                    (m, -next.evaluate() - material)
+                    (m, Value::lower() / 2 + self.history.get(m, pos.turn()))
                 }
             })
             .collect();
@@ -458,7 +455,6 @@ impl Engine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chess::Move;
     use proptest::{prop_assume, sample::Selector};
     use test_strategy::proptest;
 

--- a/lib/uci.rs
+++ b/lib/uci.rs
@@ -205,10 +205,8 @@ impl<I: FusedStream<Item = String> + Unpin, O: Sink<String> + Unpin> Uci<I, O> {
                 ["eval"] => {
                     let pos = &self.position;
                     let turn = self.position.turn();
-                    let mat = pos.material().evaluate().perspective(turn);
-                    let psn = pos.positional().evaluate().perspective(turn);
-                    let val = pos.evaluate().perspective(turn);
-                    let info = format!("info material {mat:+} positional {psn:+} value {val:+}");
+                    let value = pos.evaluate().perspective(turn);
+                    let info = format!("info value {value:+}");
                     self.output.send(info).await?;
                 }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                           -37       5    9000    2012    2975    4013   4018.5   44.6%   44.6%
   1 Blackmarlin-9.0                81       9    3000    1191     508    1301   1841.5   61.4%   43.4%
   2 Renegade-1.1.0                 52       9    3000    1070     621    1309   1724.5   57.5%   43.6%
   3 Halogen-12.0                  -20       9    3000     714     883    1403   1415.5   47.2%   46.8%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     68     62     61     70     72     56     61     55     51     62     54     51     61     61     53    898
   Score   7826   7229   7485   8296   8095   7685   7307   6912   6387   7309   6467   6552   6924   7286   6783 108543
Score(%)   92.1   90.4   87.0   93.2   95.2   96.1   89.1   86.4   90.0   92.5   92.4   88.5   92.3   92.2   92.9   91.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 96.1%, "Re-Capturing"
2. STS 05, 95.2%, "Bishop vs Knight"
3. STS 04, 93.2%, "Square Vacancy"
4. STS 15, 92.9%, "Avoid Pointless Exchange"
5. STS 10, 92.5%, "Simplification"

:: Top 5 STS with low result ::
1. STS 08, 86.4%, "Advancement of f/g/h Pawns"
2. STS 03, 87.0%, "Knight Outposts"
3. STS 12, 88.5%, "Center Control"
4. STS 07, 89.1%, "Offer of Simplification"
5. STS 09, 90.0%, "Advancement of a/b/c Pawns"
```