### PR TITLE
Extend history heuristic to non-quiet moves

### DIFF
--- a/lib/search/history.rs
+++ b/lib/search/history.rs
@@ -1,31 +1,40 @@
-use crate::chess::{Color, Move};
-use crate::util::Assume;
+use crate::chess::{Move, Position, Role};
+use crate::util::{AlignTo64, Assume};
 use derive_more::Debug;
+use std::mem::{size_of, MaybeUninit};
 use std::sync::atomic::{AtomicI8, Ordering::Relaxed};
-use std::{array, mem::size_of};
+
+#[cfg(test)]
+use proptest::prelude::*;
 
 /// [Historical statistics] about a [`Move`].
 ///
 /// [Historical statistics]: https://www.chessprogramming.org/History_Heuristic
 #[derive(Debug)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[debug("History({})", size_of::<Self>())]
-pub struct History([[[AtomicI8; 2]; 64]; 64]);
+pub struct History(
+    #[cfg_attr(test, strategy(any::<[i8; 6 * 64 * 64 * 2]>()
+        .prop_map(|q| unsafe { std::mem::transmute_copy(&q) })))]
+    AlignTo64<[[[[AtomicI8; 6]; 64]; 64]; 2]>,
+);
 
 impl Default for History {
     #[inline(always)]
     fn default() -> Self {
-        History(array::from_fn(|_| {
-            array::from_fn(|_| [AtomicI8::new(0), AtomicI8::new(0)])
-        }))
+        History(unsafe { MaybeUninit::zeroed().assume_init() })
     }
 }
 
 impl History {
     /// Update statistics about a [`Move`] for a side to move at a given draft.
     #[inline(always)]
-    pub fn update(&self, m: Move, side: Color, bonus: i8) {
+    pub fn update(&self, pos: &Position, m: Move, bonus: i8) {
+        let (wc, wt) = (m.whence() as usize, m.whither() as usize);
+        let victim = pos[m.whither()].map_or(Role::King, |p| p.role()) as usize;
+        let slot = &self.0[pos.turn() as usize][wc][wt][victim];
+
         let bonus = bonus.max(-i8::MAX);
-        let slot = &self.0[m.whence() as usize][m.whither() as usize][side as usize];
         let result = slot.fetch_update(Relaxed, Relaxed, |h| {
             Some((bonus as i16 - bonus.abs() as i16 * h as i16 / 127 + h as i16) as i8)
         });
@@ -35,26 +44,32 @@ impl History {
 
     /// Returns the history bonus for a [`Move`].
     #[inline(always)]
-    pub fn get(&self, m: Move, side: Color) -> i8 {
-        self.0[m.whence() as usize][m.whither() as usize][side as usize].load(Relaxed)
+    pub fn get(&self, pos: &Position, m: Move) -> i8 {
+        let (wc, wt) = (m.whence() as usize, m.whither() as usize);
+        let victim = pos[m.whither()].map_or(Role::King, |p| p.role()) as usize;
+        self.0[pos.turn() as usize][wc][wt][victim].load(Relaxed)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::sample::Selector;
     use std::fmt::Debug;
     use test_strategy::proptest;
 
     #[proptest]
     fn update_only_changes_history_of_given_move(
-        c: Color,
+        #[by_ref] h: History,
+        #[filter(#pos.outcome().is_none())] pos: Position,
+        #[map(|s: Selector| s.select(#pos.moves().flatten()))] m: Move,
+        #[map(|s: Selector| s.select(#pos.moves().flatten()))]
+        #[filter(#m != #n)]
+        n: Move,
         b: i8,
-        m: Move,
-        #[filter((#m.whence(), #m.whither()) != (#n.whence(), #n.whither()))] n: Move,
     ) {
-        let h = History::default();
-        h.update(m, c, b);
-        assert_eq!(h.get(n, c), 0);
+        let prev = h.get(&pos, n);
+        h.update(&pos, m, b);
+        assert_eq!(h.get(&pos, n), prev);
     }
 }


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -34       5    9000    2049    2929    4022   4060.0   45.1%   44.7% 
   1 Blackmarlin-9.0                81       9    3000    1193     503    1304   1845.0   61.5%   43.5% 
   2 Renegade-1.1.0                 49       9    3000    1038     621    1341   1708.5   57.0%   44.7% 
   3 Halogen-12.0                  -26       9    3000     698     925    1377   1386.5   46.2%   45.9%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:28s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     73     61     63     69     72     56     59     60     48     64     55     57     61     62     46    906
   Score   7953   7310   7533   8205   8192   7677   7207   7207   5993   7373   6435   7050   6777   7233   6435 108580
Score(%)   93.6   91.4   87.6   92.2   96.4   96.0   87.9   90.1   84.4   93.3   91.9   95.3   90.4   91.6   88.2   91.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 96.4%, "Bishop vs Knight"
2. STS 06, 96.0%, "Re-Capturing"
3. STS 12, 95.3%, "Center Control"
4. STS 01, 93.6%, "Undermining"
5. STS 10, 93.3%, "Simplification"

:: Top 5 STS with low result ::
1. STS 09, 84.4%, "Advancement of a/b/c Pawns"
2. STS 03, 87.6%, "Knight Outposts"
3. STS 07, 87.9%, "Offer of Simplification"
4. STS 15, 88.2%, "Avoid Pointless Exchange"
5. STS 08, 90.1%, "Advancement of f/g/h Pawns"
```