### PR TITLE
Tweak history heuristic margins

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -275,11 +275,11 @@ impl Engine {
                 if Some(m) == transposed.moves().next() {
                     return (m, Value::upper());
                 } else if killers.contains(m) {
-                    return (m, Value::new(25));
+                    return (m, Value::new(128));
                 }
 
                 let gain = if m.is_quiet() {
-                    Value::lower() / 2
+                    Value::new(0)
                 } else {
                     pos.gain(m)
                 };
@@ -338,7 +338,7 @@ impl Engine {
             next.play(m);
 
             self.tt.prefetch(next.zobrist());
-            if draft < 4 && !pos.is_check() && !next.is_check() && gain < Value::lower() / 2 {
+            if gain < 0 && draft < 4 && !pos.is_check() && !next.is_check() {
                 let deficit = alpha + next.evaluate();
                 if self.fp(deficit, draft).is_some_and(|d| d <= 0) {
                     #[cfg(not(test))]

--- a/lib/search/history.rs
+++ b/lib/search/history.rs
@@ -64,7 +64,7 @@ mod tests {
         #[filter(#pos.outcome().is_none())] pos: Position,
         #[map(|s: Selector| s.select(#pos.moves().flatten()))] m: Move,
         #[map(|s: Selector| s.select(#pos.moves().flatten()))]
-        #[filter(#m != #n)]
+        #[filter((#m.whence(), #m.whither()) != (#n.whence(), #n.whither()))]
         n: Move,
         b: i8,
     ) {


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -32       5    9000    2129    2948    3923   4090.5   45.5%   43.6% 
   1 Blackmarlin-9.0                81       9    3000    1203     520    1277   1841.5   61.4%   42.6% 
   2 Renegade-1.1.0                 41       9    3000    1026     676    1298   1675.0   55.8%   43.3% 
   3 Halogen-12.0                  -25       9    3000     719     933    1348   1393.0   46.4%   44.9%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:29s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     72     59     67     74     68     53     57     57     46     66     52     58     61     61     47    898
   Score   7940   6956   7771   8429   8081   7577   7193   7088   6040   7503   6424   6759   6985   7301   6664 108711
Score(%)   93.4   87.0   90.4   94.7   95.1   94.7   87.7   88.6   85.1   95.0   91.8   91.3   93.1   92.4   91.3   91.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 95.1%, "Bishop vs Knight"
2. STS 10, 95.0%, "Simplification"
3. STS 06, 94.7%, "Re-Capturing"
4. STS 04, 94.7%, "Square Vacancy"
5. STS 01, 93.4%, "Undermining"

:: Top 5 STS with low result ::
1. STS 09, 85.1%, "Advancement of a/b/c Pawns"
2. STS 02, 87.0%, "Open Files and Diagonals"
3. STS 07, 87.7%, "Offer of Simplification"
4. STS 08, 88.6%, "Advancement of f/g/h Pawns"
5. STS 03, 90.4%, "Knight Outposts"
```