### PR TITLE
Further simplify futility pruning

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -349,7 +349,7 @@ impl Engine {
 
         let (head, tail) = self.driver.drive(head, tail, &moves, |score, m, gain, n| {
             let alpha = match score {
-                s if s >= beta => return Err(ControlFlow::Break),
+                s if s >= beta => return Ok(None),
                 s => s.max(alpha),
             };
 
@@ -362,10 +362,7 @@ impl Engine {
                 if self.fp(deficit, draft).is_some_and(|d| d <= 0) {
                     #[cfg(not(test))]
                     // The futility pruning heuristic is not exact.
-                    return match draft.get() {
-                        ..3 => Err(ControlFlow::Break),
-                        3.. => Err(ControlFlow::Continue),
-                    };
+                    return Ok(None);
                 }
             }
 
@@ -381,7 +378,7 @@ impl Engine {
                 _ => -self.ab(&next, -beta..-alpha, depth, ply + 1, ctrl)?,
             };
 
-            Ok(partial)
+            Ok(Some(partial))
         })?;
 
         self.record(pos, &moves, bounds, depth, ply, head, tail.score());


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -25       5    9000    2096    2751    4153   4172.5   46.4%   46.1% 
   1 Blackmarlin-9.0                64       9    3000    1088     540    1372   1774.0   59.1%   45.7% 
   2 Renegade-1.1.0                 38       9    3000     971     642    1387   1664.5   55.5%   46.2% 
   3 Halogen-12.0                  -26       9    3000     692     914    1394   1389.0   46.3%   46.5%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     66     53     63     72     75     64     57     51     50     60     53     55     61     61     48    889
   Score   7654   6910   7533   8170   8151   7775   7124   6794   6264   7231   6301   6837   6944   7229   6538 107455
Score(%)   90.0   86.4   87.6   91.8   95.9   97.2   86.9   84.9   88.2   91.5   90.0   92.4   92.6   91.5   89.6   90.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 97.2%, "Re-Capturing"
2. STS 05, 95.9%, "Bishop vs Knight"
3. STS 13, 92.6%, "Pawn Play in the Center"
4. STS 12, 92.4%, "Center Control"
5. STS 04, 91.8%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 08, 84.9%, "Advancement of f/g/h Pawns"
2. STS 02, 86.4%, "Open Files and Diagonals"
3. STS 07, 86.9%, "Offer of Simplification"
4. STS 03, 87.6%, "Knight Outposts"
5. STS 09, 88.2%, "Advancement of a/b/c Pawns"
```