### PR TITLE
Increase null move reductions

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -93,7 +93,7 @@ impl Engine {
     fn nmp(&self, surplus: Score, draft: Depth) -> Option<Depth> {
         match surplus.get() {
             ..0 => None,
-            0.. => Some(draft - 2 - draft / 4),
+            0.. => Some(draft - 3 - draft / 4),
         }
     }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -16       5    9000    2272    2683    4045   4294.5   47.7%   44.9% 
   1 Blackmarlin-9.0                60       9    3000    1104     593    1303   1755.5   58.5%   43.4% 
   2 Renegade-1.1.0                 28       9    3000     929     689    1382   1620.0   54.0%   46.1% 
   3 Halogen-12.0                  -40       9    3000     650     990    1360   1330.0   44.3%   45.3%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:29s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     69     61     65     70     63     55     57     53     48     65     52     54     59     57     44    872
   Score   7777   7216   7679   8410   7705   7654   7179   6946   6200   7444   6434   6762   6797   6951   6516 107670
Score(%)   91.5   90.2   89.3   94.5   90.6   95.7   87.5   86.8   87.3   94.2   91.9   91.4   90.6   88.0   89.3   90.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.7%, "Re-Capturing"
2. STS 04, 94.5%, "Square Vacancy"
3. STS 10, 94.2%, "Simplification"
4. STS 11, 91.9%, "Activity of the King"
5. STS 01, 91.5%, "Undermining"

:: Top 5 STS with low result ::
1. STS 08, 86.8%, "Advancement of f/g/h Pawns"
2. STS 09, 87.3%, "Advancement of a/b/c Pawns"
3. STS 07, 87.5%, "Offer of Simplification"
4. STS 14, 88.0%, "Queens and Rooks to the 7th rank"
5. STS 15, 89.3%, "Avoid Pointless Exchange"
```