### PR TITLE
Keep killers local to each thread

### DIFF
--- a/benches/search.rs
+++ b/benches/search.rs
@@ -13,7 +13,7 @@ fn bench(reps: u64, options: &Options, limits: &Limits) -> Duration {
     let mut time = Duration::ZERO;
 
     for _ in 0..reps {
-        let mut e = Engine::with_options(options);
+        let e = Engine::with_options(options);
         let stopper = Trigger::armed();
         let pos = Evaluator::default();
         let timer = Instant::now();

--- a/lib/search/control.rs
+++ b/lib/search/control.rs
@@ -7,7 +7,7 @@ use derive_more::{Display, Error};
 pub struct Interrupted;
 
 /// The search control.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Copy, Clone)]
 pub enum Control<'a> {
     #[default]
     Unlimited,


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -10       5    9000    2378    2627    3995   4375.5   48.6%   44.4% 
   1 Blackmarlin-9.0                53       9    3000    1074     622    1304   1726.0   57.5%   43.5% 
   2 Renegade-1.1.0                 24       9    3000     940     737    1323   1601.5   53.4%   44.1% 
   3 Halogen-12.0                  -47       9    3000     613    1019    1368   1297.0   43.2%   45.6%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:28s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     69     59     59     73     67     51     61     57     45     62     52     53     61     61     51    881
   Score   7982   7255   7332   8439   7942   7526   7343   7114   5912   7362   6426   6758   6902   7224   6616 108133
Score(%)   93.9   90.7   85.3   94.8   93.4   94.1   89.5   88.9   83.3   93.2   91.8   91.3   92.0   91.4   90.6   91.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 04, 94.8%, "Square Vacancy"
2. STS 06, 94.1%, "Re-Capturing"
3. STS 01, 93.9%, "Undermining"
4. STS 05, 93.4%, "Bishop vs Knight"
5. STS 10, 93.2%, "Simplification"

:: Top 5 STS with low result ::
1. STS 09, 83.3%, "Advancement of a/b/c Pawns"
2. STS 03, 85.3%, "Knight Outposts"
3. STS 08, 88.9%, "Advancement of f/g/h Pawns"
4. STS 07, 89.5%, "Offer of Simplification"
5. STS 15, 90.6%, "Avoid Pointless Exchange"
```