### PR TITLE
Implement the counter heuristic

### DIFF
--- a/lib/chess/bitboard.rs
+++ b/lib/chess/bitboard.rs
@@ -4,6 +4,11 @@ use derive_more::{Debug, *};
 use std::fmt::{self, Formatter, Write};
 use std::{cell::SyncUnsafeCell, mem::MaybeUninit};
 
+/// The [butterfly board].
+///
+/// [butterfly board]: https://www.chessprogramming.org/Butterfly_Boards
+pub type Butterfly<T> = [[T; 64]; 64];
+
 /// A set of squares on a chess board.
 #[derive(
     Default,
@@ -119,7 +124,7 @@ impl Bitboard {
     /// ```
     #[inline(always)]
     pub fn line(whence: Square, whither: Square) -> Self {
-        static LINES: SyncUnsafeCell<[[Bitboard; 64]; 64]> =
+        static LINES: SyncUnsafeCell<Butterfly<Bitboard>> =
             unsafe { MaybeUninit::zeroed().assume_init() };
 
         #[cold]
@@ -162,7 +167,7 @@ impl Bitboard {
     /// ```
     #[inline(always)]
     pub fn segment(whence: Square, whither: Square) -> Self {
-        static SEGMENTS: SyncUnsafeCell<[[Bitboard; 64]; 64]> =
+        static SEGMENTS: SyncUnsafeCell<Butterfly<Bitboard>> =
             unsafe { MaybeUninit::zeroed().assume_init() };
 
         #[cold]

--- a/lib/search.rs
+++ b/lib/search.rs
@@ -1,6 +1,8 @@
+mod continuation;
 mod control;
 mod depth;
 mod engine;
+mod gravity;
 mod history;
 mod killers;
 mod limits;
@@ -11,9 +13,11 @@ mod pv;
 mod score;
 mod transposition;
 
+pub use continuation::*;
 pub use control::*;
 pub use depth::*;
 pub use engine::*;
+pub use gravity::*;
 pub use history::*;
 pub use killers::*;
 pub use limits::*;

--- a/lib/search/continuation.rs
+++ b/lib/search/continuation.rs
@@ -1,0 +1,51 @@
+use crate::chess::{Move, Position, Role};
+use crate::search::{Graviton, Gravity};
+use crate::util::Assume;
+use derive_more::Debug;
+use std::mem::MaybeUninit;
+
+#[derive(Debug)]
+pub struct Reply([[Graviton; 64]; 12]);
+
+impl Default for Reply {
+    #[inline(always)]
+    fn default() -> Self {
+        Self(unsafe { MaybeUninit::zeroed().assume_init() })
+    }
+}
+
+impl Gravity for Reply {
+    type Bonus = <Graviton as Gravity>::Bonus;
+
+    #[inline(always)]
+    fn get(&self, pos: &Position, m: Move) -> Self::Bonus {
+        let piece = pos[m.whence()].assume() as usize;
+        self.0[piece][m.whither() as usize].get(pos, m)
+    }
+
+    #[inline(always)]
+    fn update(&self, pos: &Position, m: Move, bonus: Self::Bonus) {
+        let piece = pos[m.whence()].assume() as usize;
+        self.0[piece][m.whither() as usize].update(pos, m, bonus);
+    }
+}
+
+#[derive(Debug)]
+#[debug("Continuation")]
+pub struct Continuation(Box<[[[Reply; 6]; 64]; 12]>);
+
+impl Default for Continuation {
+    #[inline(always)]
+    fn default() -> Self {
+        Self(unsafe { Box::new_zeroed().assume_init() })
+    }
+}
+
+impl Continuation {
+    #[inline(always)]
+    pub fn reply(&self, pos: &Position, m: Move) -> &Reply {
+        let piece = pos[m.whence()].assume() as usize;
+        let victim = pos[m.whither()].map_or(Role::King, |p| p.role()) as usize;
+        &self.0[piece][m.whither() as usize][victim]
+    }
+}

--- a/lib/search/gravity.rs
+++ b/lib/search/gravity.rs
@@ -1,0 +1,74 @@
+use crate::chess::{Move, Position};
+use crate::util::Assume;
+use derive_more::Debug;
+use std::sync::atomic::{AtomicI8, Ordering::Relaxed};
+
+#[cfg(test)]
+use proptest::prelude::*;
+
+pub trait Gravity {
+    /// The history bonus.
+    type Bonus;
+
+    /// Returns the accumulated history [`Self::Bonus`] for a [`Move`].
+    fn get(&self, pos: &Position, m: Move) -> Self::Bonus;
+
+    /// Update the [`Self::Bonus`] for a [`Move`].
+    fn update(&self, pos: &Position, m: Move, bonus: Self::Bonus);
+}
+
+/// The unit of [`Gravity`].
+#[derive(Debug, Default)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
+#[repr(transparent)]
+pub struct Graviton(#[cfg_attr(test, strategy(any::<i8>().prop_map_into()))] AtomicI8);
+
+impl Gravity for Graviton {
+    type Bonus = i8;
+
+    #[inline(always)]
+    fn get(&self, _: &Position, _: Move) -> Self::Bonus {
+        self.0.load(Relaxed)
+    }
+
+    #[inline(always)]
+    fn update(&self, _: &Position, _: Move, bonus: Self::Bonus) {
+        let bonus = bonus.max(-i8::MAX);
+        let result = self.0.fetch_update(Relaxed, Relaxed, |h| {
+            Some((bonus as i16 - bonus.abs() as i16 * h as i16 / 127 + h as i16) as i8)
+        });
+
+        result.assume();
+    }
+}
+
+impl<T: Gravity> Gravity for &T {
+    type Bonus = T::Bonus;
+
+    #[inline(always)]
+    fn get(&self, pos: &Position, m: Move) -> Self::Bonus {
+        (*self).get(pos, m)
+    }
+
+    #[inline(always)]
+    fn update(&self, pos: &Position, m: Move, bonus: Self::Bonus) {
+        (*self).update(pos, m, bonus)
+    }
+}
+
+impl<T: Gravity<Bonus: Default>> Gravity for Option<T> {
+    type Bonus = T::Bonus;
+
+    #[inline(always)]
+    fn get(&self, pos: &Position, m: Move) -> Self::Bonus {
+        self.as_ref()
+            .map_or_else(Default::default, |g| g.get(pos, m))
+    }
+
+    #[inline(always)]
+    fn update(&self, pos: &Position, m: Move, bonus: Self::Bonus) {
+        if let Some(g) = self {
+            g.update(pos, m, bonus);
+        }
+    }
+}

--- a/lib/search/history.rs
+++ b/lib/search/history.rs
@@ -1,75 +1,33 @@
-use crate::chess::{Move, Position, Role};
-use crate::util::{AlignTo64, Assume};
+use crate::chess::{Butterfly, Move, Position};
+use crate::search::{Graviton, Gravity};
 use derive_more::Debug;
-use std::mem::{size_of, MaybeUninit};
-use std::sync::atomic::{AtomicI8, Ordering::Relaxed};
-
-#[cfg(test)]
-use proptest::prelude::*;
 
 /// [Historical statistics] about a [`Move`].
 ///
 /// [Historical statistics]: https://www.chessprogramming.org/History_Heuristic
 #[derive(Debug)]
-#[cfg_attr(test, derive(test_strategy::Arbitrary))]
-#[debug("History({})", size_of::<Self>())]
-pub struct History(
-    #[cfg_attr(test, strategy(any::<[i8; 6 * 64 * 64 * 2]>()
-        .prop_map(|q| unsafe { std::mem::transmute_copy(&q) })))]
-    AlignTo64<[[[[AtomicI8; 6]; 64]; 64]; 2]>,
-);
+#[debug("History")]
+pub struct History(Box<[[Butterfly<Graviton>; 2]; 2]>);
 
 impl Default for History {
     #[inline(always)]
     fn default() -> Self {
-        History(unsafe { MaybeUninit::zeroed().assume_init() })
+        Self(unsafe { Box::new_zeroed().assume_init() })
     }
 }
 
-impl History {
-    /// Update statistics about a [`Move`] for a side to move at a given draft.
+impl Gravity for History {
+    type Bonus = <Graviton as Gravity>::Bonus;
+
     #[inline(always)]
-    pub fn update(&self, pos: &Position, m: Move, bonus: i8) {
+    fn get(&self, pos: &Position, m: Move) -> Self::Bonus {
         let (wc, wt) = (m.whence() as usize, m.whither() as usize);
-        let victim = pos[m.whither()].map_or(Role::King, |p| p.role()) as usize;
-        let slot = &self.0[pos.turn() as usize][wc][wt][victim];
-
-        let bonus = bonus.max(-i8::MAX);
-        let result = slot.fetch_update(Relaxed, Relaxed, |h| {
-            Some((bonus as i16 - bonus.abs() as i16 * h as i16 / 127 + h as i16) as i8)
-        });
-
-        result.assume();
+        self.0[pos.turn() as usize][m.is_capture() as usize][wc][wt].get(pos, m)
     }
 
-    /// Returns the history bonus for a [`Move`].
     #[inline(always)]
-    pub fn get(&self, pos: &Position, m: Move) -> i8 {
+    fn update(&self, pos: &Position, m: Move, bonus: Self::Bonus) {
         let (wc, wt) = (m.whence() as usize, m.whither() as usize);
-        let victim = pos[m.whither()].map_or(Role::King, |p| p.role()) as usize;
-        self.0[pos.turn() as usize][wc][wt][victim].load(Relaxed)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use proptest::sample::Selector;
-    use std::fmt::Debug;
-    use test_strategy::proptest;
-
-    #[proptest]
-    fn update_only_changes_history_of_given_move(
-        #[by_ref] h: History,
-        #[filter(#pos.outcome().is_none())] pos: Position,
-        #[map(|s: Selector| s.select(#pos.moves().flatten()))] m: Move,
-        #[map(|s: Selector| s.select(#pos.moves().flatten()))]
-        #[filter((#m.whence(), #m.whither()) != (#n.whence(), #n.whither()))]
-        n: Move,
-        b: i8,
-    ) {
-        let prev = h.get(&pos, n);
-        h.update(&pos, m, b);
-        assert_eq!(h.get(&pos, n), prev);
+        self.0[pos.turn() as usize][m.is_capture() as usize][wc][wt].update(pos, m, bonus);
     }
 }


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -2       5    9000    2493    2545    3962   4474.0   49.7%   44.0% 
   1 Blackmarlin-9.0                48       9    3000    1050     639    1311   1705.5   56.9%   43.7% 
   2 Renegade-1.1.0                 15       9    3000     886     757    1357   1564.5   52.1%   45.2% 
   3 Halogen-12.0                  -57       9    3000     609    1097    1294   1256.0   41.9%   43.1%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     71     60     66     69     70     58     59     54     44     59     53     55     60     58     45    881
   Score   8010   7234   7847   8261   8059   7625   7112   6830   5929   7302   6554   6831   6803   7183   6554 108134
Score(%)   94.2   90.4   91.2   92.8   94.8   95.3   86.7   85.4   83.5   92.4   93.6   92.3   90.7   90.9   89.8   91.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.3%, "Re-Capturing"
2. STS 05, 94.8%, "Bishop vs Knight"
3. STS 01, 94.2%, "Undermining"
4. STS 11, 93.6%, "Activity of the King"
5. STS 04, 92.8%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 09, 83.5%, "Advancement of a/b/c Pawns"
2. STS 08, 85.4%, "Advancement of f/g/h Pawns"
3. STS 07, 86.7%, "Offer of Simplification"
4. STS 15, 89.8%, "Avoid Pointless Exchange"
5. STS 02, 90.4%, "Open Files and Diagonals"
```