### PR TITLE
Reduce conditional behavior for tests

### DIFF
--- a/lib/nnue/value.rs
+++ b/lib/nnue/value.rs
@@ -9,7 +9,7 @@ pub struct ValueRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as
 unsafe impl Integer for ValueRepr {
     type Repr = i16;
     const MIN: Self::Repr = -Self::MAX;
-    const MAX: Self::Repr = 4000;
+    const MAX: Self::Repr = 3999;
 }
 
 /// A position's static evaluation.

--- a/lib/search/depth.rs
+++ b/lib/search/depth.rs
@@ -14,7 +14,7 @@ unsafe impl Integer for DepthRepr {
     const MAX: Self::Repr = 63;
 
     #[cfg(test)]
-    const MAX: Self::Repr = 3;
+    const MAX: Self::Repr = 7;
 }
 
 /// The search depth.

--- a/lib/search/ply.rs
+++ b/lib/search/ply.rs
@@ -7,14 +7,8 @@ pub struct PlyRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as I
 
 unsafe impl Integer for PlyRepr {
     type Repr = i8;
-
     const MIN: Self::Repr = -Self::MAX;
-
-    #[cfg(not(test))]
     const MAX: Self::Repr = 95;
-
-    #[cfg(test)]
-    const MAX: Self::Repr = 7;
 }
 
 /// The number of half-moves played.

--- a/lib/search/score.rs
+++ b/lib/search/score.rs
@@ -18,8 +18,8 @@ pub type Score = Saturating<ScoreRepr>;
 
 impl Score {
     const _CONDITION: () = const {
-        assert!(Value::MAX + Ply::MAX as i16 <= Self::MAX);
-        assert!(Value::MIN + Ply::MIN as i16 >= Self::MIN);
+        assert!(Value::MAX + (Ply::MAX as i16) < Self::MAX);
+        assert!(Value::MIN + (Ply::MIN as i16) > Self::MIN);
     };
 
     /// Returns number of plies to mate, if one is in the horizon.


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -1       5    9000    2515    2536    3949   4489.5   49.9%   43.9% 
   1 Blackmarlin-9.0                52       9    3000    1088     639    1273   1724.5   57.5%   42.4% 
   2 Renegade-1.1.0                 10       9    3000     881     798    1321   1541.5   51.4%   44.0% 
   3 Halogen-12.0                  -60       9    3000     567    1078    1355   1244.5   41.5%   45.2%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     71     60     64     74     72     58     61     60     50     62     56     56     62     63     47    916
   Score   7896   7330   7724   8455   8269   7666   7367   7267   6246   7349   6610   6763   6938   7341   6511 109732
Score(%)   92.9   91.6   89.8   95.0   97.3   95.8   89.8   90.8   88.0   93.0   94.4   91.4   92.5   92.9   89.2   92.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 97.3%, "Bishop vs Knight"
2. STS 06, 95.8%, "Re-Capturing"
3. STS 04, 95.0%, "Square Vacancy"
4. STS 11, 94.4%, "Activity of the King"
5. STS 10, 93.0%, "Simplification"

:: Top 5 STS with low result ::
1. STS 09, 88.0%, "Advancement of a/b/c Pawns"
2. STS 15, 89.2%, "Avoid Pointless Exchange"
3. STS 03, 89.8%, "Knight Outposts"
4. STS 07, 89.8%, "Offer of Simplification"
5. STS 08, 90.8%, "Advancement of f/g/h Pawns"
```