### PR TITLE
Tweak null move pruning margins

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -99,7 +99,8 @@ impl<'a> Search<'a> {
     fn nmp(&self, surplus: Score, draft: Depth) -> Option<Depth> {
         match surplus.get() {
             ..0 => None,
-            0.. => Some(draft - 3 - draft / 4),
+            s @ 0..40 => Some(draft - (s + 20) / 20 - draft / 4),
+            40.. => Some(draft - 3 - draft / 4),
         }
     }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Halogen-12.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                            16       5    9000    2540    2116    4344   4712.0   52.4%   48.3%
   1 Blackmarlin-9.0                33       9    3000     918     632    1450   1643.0   54.8%   48.3%
   2 Renegade-1.1.0                -12       9    3000     729     835    1436   1447.0   48.2%   47.9%
   3 Halogen-12.0                  -71       9    3000     469    1073    1458   1198.0   39.9%   48.6%
```

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Akimbo-1.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                           -12       5    9000    2233    2542    4225   4345.5   48.3%   46.9%
   1 Blackmarlin-9.0                30       9    3000     908     652    1440   1628.0   54.3%   48.0%
   2 Akimbo-1.0                     14       9    3000     864     747    1389   1558.5   51.9%   46.3%
   3 Renegade-1.1.0                 -7       9    3000     770     834    1396   1468.0   48.9%   46.5%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:27s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     71     61     63     72     73     58     62     61     50     64     53     56     62     63     46    915
   Score   7993   7247   7656   8438   8204   7651   7452   7191   6172   7450   6385   6865   6933   7320   6390 109347
Score(%)   94.0   90.6   89.0   94.8   96.5   95.6   90.9   89.9   86.9   94.3   91.2   92.8   92.4   92.7   87.5   92.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 96.5%, "Bishop vs Knight"
2. STS 06, 95.6%, "Re-Capturing"
3. STS 04, 94.8%, "Square Vacancy"
4. STS 10, 94.3%, "Simplification"
5. STS 01, 94.0%, "Undermining"

:: Top 5 STS with low result ::
1. STS 09, 86.9%, "Advancement of a/b/c Pawns"
2. STS 15, 87.5%, "Avoid Pointless Exchange"
3. STS 03, 89.0%, "Knight Outposts"
4. STS 08, 89.9%, "Advancement of f/g/h Pawns"
5. STS 02, 90.6%, "Open Files and Diagonals"
```