### PR TITLE
Simplify counter history heuristic

### DIFF
--- a/lib/search/continuation.rs
+++ b/lib/search/continuation.rs
@@ -5,7 +5,7 @@ use derive_more::Debug;
 use std::mem::MaybeUninit;
 
 #[derive(Debug)]
-pub struct Reply([[Graviton; 64]; 12]);
+pub struct Reply([[Graviton; 64]; 6]);
 
 impl Default for Reply {
     #[inline(always)]
@@ -19,13 +19,13 @@ impl Gravity for Reply {
 
     #[inline(always)]
     fn get(&self, pos: &Position, m: Move) -> Self::Bonus {
-        let piece = pos[m.whence()].assume() as usize;
+        let piece = pos[m.whence()].assume().role() as usize;
         self.0[piece][m.whither() as usize].get(pos, m)
     }
 
     #[inline(always)]
     fn update(&self, pos: &Position, m: Move, bonus: Self::Bonus) {
-        let piece = pos[m.whence()].assume() as usize;
+        let piece = pos[m.whence()].assume().role() as usize;
         self.0[piece][m.whither() as usize].update(pos, m, bonus);
     }
 }


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Akimbo-1.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                           -10       5    9000    2258    2516    4226   4371.0   48.6%   47.0%
   1 Blackmarlin-9.0                21       9    3000     895     711    1394   1592.0   53.1%   46.5%
   2 Akimbo-1.0                     14       9    3000     871     747    1382   1562.0   52.1%   46.1%
   3 Renegade-1.1.0                 -6       9    3000     750     800    1450   1475.0   49.2%   48.3%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:26s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     72     65     65     74     75     61     62     56     51     62     51     54     63     56     47    914
   Score   8064   7450   7670   8519   8153   7680   7408   6947   6171   7326   6415   6802   6973   7045   6495 109118
Score(%)   94.9   93.1   89.2   95.7   95.9   96.0   90.3   86.8   86.9   92.7   91.6   91.9   93.0   89.2   89.0   91.9

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 96.0%, "Re-Capturing"
2. STS 05, 95.9%, "Bishop vs Knight"
3. STS 04, 95.7%, "Square Vacancy"
4. STS 01, 94.9%, "Undermining"
5. STS 02, 93.1%, "Open Files and Diagonals"

:: Top 5 STS with low result ::
1. STS 08, 86.8%, "Advancement of f/g/h Pawns"
2. STS 09, 86.9%, "Advancement of a/b/c Pawns"
3. STS 15, 89.0%, "Avoid Pointless Exchange"
4. STS 14, 89.2%, "Queens and Rooks to the 7th rank"
5. STS 03, 89.2%, "Knight Outposts"
```