### PR TITLE
Refine history heuristic with information about checks

### DIFF
--- a/lib/search/continuation.rs
+++ b/lib/search/continuation.rs
@@ -14,19 +14,25 @@ impl Default for Reply {
     }
 }
 
+impl Reply {
+    #[inline(always)]
+    fn graviton(&self, pos: &Position, m: Move) -> &Graviton {
+        let piece = pos[m.whence()].assume().role() as usize;
+        &self.0[piece][m.whither() as usize]
+    }
+}
+
 impl Gravity for Reply {
     type Bonus = <Graviton as Gravity>::Bonus;
 
     #[inline(always)]
     fn get(&self, pos: &Position, m: Move) -> Self::Bonus {
-        let piece = pos[m.whence()].assume().role() as usize;
-        self.0[piece][m.whither() as usize].get(pos, m)
+        self.graviton(pos, m).get(pos, m)
     }
 
     #[inline(always)]
     fn update(&self, pos: &Position, m: Move, bonus: Self::Bonus) {
-        let piece = pos[m.whence()].assume().role() as usize;
-        self.0[piece][m.whither() as usize].update(pos, m, bonus);
+        self.graviton(pos, m).update(pos, m, bonus);
     }
 }
 

--- a/lib/search/history.rs
+++ b/lib/search/history.rs
@@ -1,18 +1,30 @@
 use crate::chess::{Butterfly, Move, Position};
 use crate::search::{Graviton, Gravity};
 use derive_more::with_trait::Debug;
+use std::mem::MaybeUninit;
 
 /// [Historical statistics] about a [`Move`].
 ///
 /// [Historical statistics]: https://www.chessprogramming.org/History_Heuristic
 #[derive(Debug)]
 #[debug("History")]
-pub struct History(Box<[[Butterfly<Graviton>; 2]; 2]>);
+pub struct History([[[Butterfly<Graviton>; 2]; 2]; 2]);
 
 impl Default for History {
     #[inline(always)]
     fn default() -> Self {
-        Self(unsafe { Box::new_zeroed().assume_init() })
+        Self(unsafe { MaybeUninit::zeroed().assume_init() })
+    }
+}
+
+impl History {
+    #[inline(always)]
+    fn graviton(&self, pos: &Position, m: Move) -> &Graviton {
+        let (wc, wt) = (m.whence() as usize, m.whither() as usize);
+        let turn = pos.turn() as usize;
+        let is_check = pos.is_check() as usize;
+        let is_capture = m.is_capture() as usize;
+        &self.0[turn][is_check][is_capture][wc][wt]
     }
 }
 
@@ -21,13 +33,11 @@ impl Gravity for History {
 
     #[inline(always)]
     fn get(&self, pos: &Position, m: Move) -> Self::Bonus {
-        let (wc, wt) = (m.whence() as usize, m.whither() as usize);
-        self.0[pos.turn() as usize][m.is_capture() as usize][wc][wt].get(pos, m)
+        self.graviton(pos, m).get(pos, m)
     }
 
     #[inline(always)]
     fn update(&self, pos: &Position, m: Move, bonus: Self::Bonus) {
-        let (wc, wt) = (m.whence() as usize, m.whither() as usize);
-        self.0[pos.turn() as usize][m.is_capture() as usize][wc][wt].update(pos, m, bonus);
+        self.graviton(pos, m).update(pos, m, bonus);
     }
 }

--- a/lib/uci.rs
+++ b/lib/uci.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use std::{fmt::Debug, io::Write, mem::transmute, str, thread};
 
 #[cfg(test)]
-use proptest::prelude::*;
+use proptest::{prelude::*, strategy::LazyJust};
 
 /// Runs the provided closure on a thread where blocking is acceptable.
 ///
@@ -50,8 +50,9 @@ impl PartialEq<str> for UciMove {
 pub struct Uci<I, O> {
     #[cfg_attr(test, strategy(Just(args.clone())))]
     input: I,
-    #[cfg_attr(test, strategy(Just(O::default())))]
+    #[cfg_attr(test, strategy(LazyJust::new(O::default)))]
     output: O,
+    #[cfg_attr(test, strategy(LazyJust::new(move || Engine::with_options(&#options))))]
     engine: Engine,
     options: Options,
     position: Evaluator,


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Akimbo-1.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                             7       5    9000    2439    2267    4294   4586.0   51.0%   47.7% 
   1 Blackmarlin-9.0                13       9    3000     823     715    1462   1554.0   51.8%   48.7% 
   2 Akimbo-1.0                     -2       9    3000     785     804    1411   1490.5   49.7%   47.0% 
   3 Renegade-1.1.0                -30       9    3000     659     920    1421   1369.5   45.6%   47.4%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:23s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     70     59     64     71     73     60     61     60     51     65     56     54     63     59     53    919
   Score   7962   7226   7818   8353   8215   7661   7334   7326   6179   7457   6622   6835   7078   7176   6871 110113
Score(%)   93.7   90.3   90.9   93.9   96.6   95.8   89.4   91.6   87.0   94.4   94.6   92.4   94.4   90.8   94.1   92.7

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 96.6%, "Bishop vs Knight"
2. STS 06, 95.8%, "Re-Capturing"
3. STS 11, 94.6%, "Activity of the King"
4. STS 10, 94.4%, "Simplification"
5. STS 13, 94.4%, "Pawn Play in the Center"

:: Top 5 STS with low result ::
1. STS 09, 87.0%, "Advancement of a/b/c Pawns"
2. STS 07, 89.4%, "Offer of Simplification"
3. STS 02, 90.3%, "Open Files and Diagonals"
4. STS 14, 90.8%, "Queens and Rooks to the 7th rank"
5. STS 03, 90.9%, "Knight Outposts"
```