### PR TITLE
Revert "refine history heuristic with information about checks"

### DIFF
--- a/lib/search/history.rs
+++ b/lib/search/history.rs
@@ -8,7 +8,7 @@ use std::mem::MaybeUninit;
 /// [Historical statistics]: https://www.chessprogramming.org/History_Heuristic
 #[derive(Debug)]
 #[debug("History")]
-pub struct History([[[Butterfly<Graviton>; 2]; 2]; 2]);
+pub struct History([[Butterfly<Graviton>; 2]; 2]);
 
 impl Default for History {
     #[inline(always)]
@@ -21,10 +21,7 @@ impl History {
     #[inline(always)]
     fn graviton(&self, pos: &Position, m: Move) -> &Graviton {
         let (wc, wt) = (m.whence() as usize, m.whither() as usize);
-        let turn = pos.turn() as usize;
-        let is_check = pos.is_check() as usize;
-        let is_capture = m.is_capture() as usize;
-        &self.0[turn][is_check][is_capture][wc][wt]
+        &self.0[pos.turn() as usize][m.is_capture() as usize][wc][wt]
     }
 }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Blackmarlin-9.0 -engine conf=Akimbo-1.0 -engine conf=Renegade-1.1.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                             7       5    9000    2422    2238    4340   4592.0   51.0%   48.2% 
   1 Akimbo-1.0                      7       9    3000     809     751    1440   1529.0   51.0%   48.0% 
   2 Blackmarlin-9.0                 2       9    3000     798     781    1421   1508.5   50.3%   47.4% 
   3 Renegade-1.1.0                -30       9    3000     631     890    1479   1370.5   45.7%   49.3%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:25s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     68     58     63     74     71     63     60     55     52     64     52     53     64     60     50    907
   Score   7926   7216   7544   8473   8162   7726   7300   6945   6373   7452   6433   6822   7057   7117   6802 109348
Score(%)   93.2   90.2   87.7   95.2   96.0   96.6   89.0   86.8   89.8   94.3   91.9   92.2   94.1   90.1   93.2   92.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 96.6%, "Re-Capturing"
2. STS 05, 96.0%, "Bishop vs Knight"
3. STS 04, 95.2%, "Square Vacancy"
4. STS 10, 94.3%, "Simplification"
5. STS 13, 94.1%, "Pawn Play in the Center"

:: Top 5 STS with low result ::
1. STS 08, 86.8%, "Advancement of f/g/h Pawns"
2. STS 03, 87.7%, "Knight Outposts"
3. STS 07, 89.0%, "Offer of Simplification"
4. STS 09, 89.8%, "Advancement of a/b/c Pawns"
5. STS 14, 90.1%, "Queens and Rooks to the 7th rank"
```