### PR TITLE
Special case PVS for the root node

### DIFF
--- a/lib/search/transposition.rs
+++ b/lib/search/transposition.rs
@@ -68,7 +68,7 @@ impl ScoreBound {
         (ply >= 0).assume();
 
         match *self {
-            ScoreBound::Lower(_) => Score::upper().normalize(ply),
+            ScoreBound::Lower(_) => Score::mating(ply),
             _ => self.bound(ply),
         }
     }


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=-5 elo1=0 alpha=0.05 beta=0.05 -games 2 -rounds 10000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.pgn order=random plies=8 -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=base -each tc=1.2+0.01`

```
Score of dev vs base: 794 - 717 - 1622  [0.512] 3133
...      dev playing White: 558 - 227 - 782  [0.606] 1567
...      dev playing Black: 236 - 490 - 840  [0.419] 1566
...      White vs Black: 1048 - 463 - 1622  [0.593] 3133
Elo difference: 8.5 +/- 8.4, LOS: 97.6 %, DrawRatio: 51.8 %
SPRT: llr 2.97 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```

> `cutechess-cli -sprt elo0=0 elo1=5 alpha=0.05 beta=0.05 -games 2 -rounds 10000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.pgn order=random plies=8 -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=base -each tc=3+0.025`

```
Score of dev vs base: 1034 - 917 - 2944  [0.512] 4895
...      dev playing White: 795 - 204 - 1449  [0.621] 2448
...      dev playing Black: 239 - 713 - 1495  [0.403] 2447
...      White vs Black: 1508 - 443 - 2944  [0.609] 4895
Elo difference: 8.3 +/- 6.1, LOS: 99.6 %, DrawRatio: 60.1 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:24s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     69     62     66     75     73     62     60     58     52     66     53     53     65     62     44    920
   Score   7929   7282   7720   8422   8336   7741   7305   7274   6245   7482   6603   6820   7174   7155   6512 110000
Score(%)   93.3   91.0   89.8   94.6   98.1   96.8   89.1   90.9   88.0   94.7   94.3   92.2   95.7   90.6   89.2   92.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 98.1%, "Bishop vs Knight"
2. STS 06, 96.8%, "Re-Capturing"
3. STS 13, 95.7%, "Pawn Play in the Center"
4. STS 10, 94.7%, "Simplification"
5. STS 04, 94.6%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 09, 88.0%, "Advancement of a/b/c Pawns"
2. STS 07, 89.1%, "Offer of Simplification"
3. STS 15, 89.2%, "Avoid Pointless Exchange"
4. STS 03, 89.8%, "Knight Outposts"
5. STS 14, 90.6%, "Queens and Rooks to the 7th rank"
```