### PR TITLE
Use time slightly more aggressively

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Cinder is an independent chess engine written in Rust from scratch.
 With a playing strength that is far superior to what humans are capable of,
 Cinder is primarily developed to play against other engines. It is regularly tested
-at the extremely short time control of 3s+25ms per game. The shorter the time control,
+at the extremely short time control of 1s+10ms per game. The shorter the time control,
 the stronger Cinder tends to play.
 
 ## Usage


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=5 alpha=0.05 beta=0.05 -games 2 -rounds 10000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.pgn order=random plies=8 -concurrency 12 -use-affinity -ratinginterval 10 -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.pgn):
Elo: 8.13 +/- 5.23, nElo: 12.39 +/- 7.96
LOS: 99.88 %, DrawRatio: 41.59 %, PairsRatio: 1.16
Games: 7310, Wins: 1862, Losses: 1691, Draws: 3757, Points: 3740.5 (51.17 %)
Ptnml(0-2): [164, 824, 1520, 971, 176], WL/DD Ratio: 0.55
LLR: 2.99 (-2.94, 2.94) [0.00, 5.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.1
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:25s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     68     61     68     75     68     58     61     56     53     68     49     57     65     62     50    919
   Score   7834   7122   7901   8437   8048   7661   7408   7016   6394   7595   6353   6907   7186   7381   6520 109763
Score(%)   92.2   89.0   91.9   94.8   94.7   95.8   90.3   87.7   90.1   96.1   90.8   93.3   95.8   93.4   89.3   92.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 10, 96.1%, "Simplification"
2. STS 13, 95.8%, "Pawn Play in the Center"
3. STS 06, 95.8%, "Re-Capturing"
4. STS 04, 94.8%, "Square Vacancy"
5. STS 05, 94.7%, "Bishop vs Knight"

:: Top 5 STS with low result ::
1. STS 08, 87.7%, "Advancement of f/g/h Pawns"
2. STS 02, 89.0%, "Open Files and Diagonals"
3. STS 15, 89.3%, "Avoid Pointless Exchange"
4. STS 09, 90.1%, "Advancement of a/b/c Pawns"
5. STS 07, 90.3%, "Offer of Simplification"
```
