### PR TITLE
Revert "enable -Zfmt-debug=none in release mode"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,4 +5,4 @@ rustflags = ["-Ctarget-cpu=native"]
 profile-rustflags = true
 
 [profile.release]
-rustflags = ["-Zlocation-detail=none", "-Zfmt-debug=none"]
+rustflags = ["-Zlocation-detail=none"]


### PR DESCRIPTION
This flag breaks `-Zbuild-std` on at least aarch64, as the compiler_builtins crate relies on trait Debug to generate atomic intrinsics. This reverts commit 329d2a3.