### PR TITLE
Report search time, nodes visited, and nps

### DIFF
--- a/lib/search/control.rs
+++ b/lib/search/control.rs
@@ -15,6 +15,17 @@ pub enum Control<'a> {
 }
 
 impl Control<'_> {
+    /// A reference to the node counter.
+    #[inline(always)]
+    pub fn counter(&self) -> &Counter {
+        static INFINITE: Counter = Counter::new(u64::MAX);
+
+        match self {
+            Control::Unlimited => &INFINITE,
+            Control::Limited(counter, _, _) => counter,
+        }
+    }
+
     /// A reference to the timer.
     #[inline(always)]
     pub fn timer(&self) -> &Timer {

--- a/lib/util/counter.rs
+++ b/lib/util/counter.rs
@@ -9,10 +9,16 @@ pub struct Counter {
 impl Counter {
     /// Constructs a counter with the given limit.
     #[inline(always)]
-    pub fn new(limit: u64) -> Self {
+    pub const fn new(limit: u64) -> Self {
         Counter {
             remaining: AtomicU64::new(limit),
         }
+    }
+
+    /// The number of counts remaining.
+    #[inline(always)]
+    pub fn get(&self) -> u64 {
+        self.remaining.load(Ordering::Relaxed)
     }
 
     /// Increments the counter and returns the number of counts remaining if any.


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-5 elo1=0 alpha=0.05 beta=0.05 -games 2 -rounds 10000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.pgn order=random plies=8 -concurrency 12 -use-affinity -ratinginterval 10 -recover -log file=stderr.log realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.pgn):
Elo: 3.15 +/- 4.47, nElo: 4.85 +/- 6.87
LOS: 91.67 %, DrawRatio: 42.87 %, PairsRatio: 1.06
Games: 9812, Wins: 2401, Losses: 2312, Draws: 5099, Points: 4950.5 (50.45 %)
Ptnml(0-2): [220, 1140, 2103, 1217, 226], WL/DD Ratio: 0.53
LLR: 2.99 (-2.94, 2.94) [-5.00, 0.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.3
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:25s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     72     61     71     77     74     59     64     61     52     68     53     60     63     66     46    947
   Score   8030   7221   7963   8520   8238   7708   7562   7328   6306   7563   6533   6977   7058   7474   6539 111020
Score(%)   94.5   90.3   92.6   95.7   96.9   96.3   92.2   91.6   88.8   95.7   93.3   94.3   94.1   94.6   89.6   93.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 96.9%, "Bishop vs Knight"
2. STS 06, 96.3%, "Re-Capturing"
3. STS 10, 95.7%, "Simplification"
4. STS 04, 95.7%, "Square Vacancy"
5. STS 14, 94.6%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 09, 88.8%, "Advancement of a/b/c Pawns"
2. STS 15, 89.6%, "Avoid Pointless Exchange"
3. STS 02, 90.3%, "Open Files and Diagonals"
4. STS 08, 91.6%, "Advancement of f/g/h Pawns"
5. STS 07, 92.2%, "Offer of Simplification"
```
