### PR TITLE
Improve detection of draw by insufficient material

### DIFF
--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -469,16 +469,21 @@ impl Position {
     /// [insufficient material]: https://www.chessprogramming.org/Material#InsufficientMaterial
     #[inline(always)]
     pub fn is_material_insufficient(&self) -> bool {
-        use Role::*;
+        use {Piece::*, Role::*};
         match self.occupied().len() {
             2 => true,
-            3 => !self.board.by_role(Bishop).is_empty() || !self.board.by_role(Knight).is_empty(),
-            _ => {
-                let bishops = self.board.by_role(Bishop);
-                bishops | self.board.by_role(King) == self.occupied()
-                    && (Bitboard::light().intersection(bishops).is_empty()
-                        || Bitboard::dark().intersection(bishops).is_empty())
+            3 => self.board.by_role(Bishop) | self.board.by_role(Knight) != Bitboard::empty(),
+            4 => {
+                let wb = self.board.by_piece(WhiteBishop);
+                let bb = self.board.by_piece(BlackBishop);
+
+                let dark = Bitboard::dark();
+                let light = Bitboard::light();
+
+                !(light.intersection(wb).is_empty() || light.intersection(bb).is_empty())
+                    || !(dark.intersection(wb).is_empty() || dark.intersection(bb).is_empty())
             }
+            _ => false,
         }
     }
 


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-5 elo1=0 alpha=0.05 beta=0.05 -games 2 -rounds 10000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.pgn order=random plies=8 -concurrency 12 -use-affinity -ratinginterval 10 -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.pgn):
Elo: 0.90 +/- 3.21, nElo: 1.41 +/- 5.05
LOS: 70.82 %, DrawRatio: 43.81 %, PairsRatio: 1.01
Games: 18178, Wins: 4306, Losses: 4259, Draws: 9613, Points: 9112.5 (50.13 %)
Ptnml(0-2): [368, 2168, 3982, 2191, 380], WL/DD Ratio: 0.52
LLR: 2.95 (-2.94, 2.94) [-5.00, 0.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.3
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:25s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     71     64     64     77     74     61     60     58     52     65     56     55     62     61     45    925
   Score   8005   7261   7746   8542   8246   7718   7322   7072   6290   7373   6639   6957   7049   7352   6529 110101
Score(%)   94.2   90.8   90.1   96.0   97.0   96.5   89.3   88.4   88.6   93.3   94.8   94.0   94.0   93.1   89.4   92.7

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 97.0%, "Bishop vs Knight"
2. STS 06, 96.5%, "Re-Capturing"
3. STS 04, 96.0%, "Square Vacancy"
4. STS 11, 94.8%, "Activity of the King"
5. STS 01, 94.2%, "Undermining"

:: Top 5 STS with low result ::
1. STS 08, 88.4%, "Advancement of f/g/h Pawns"
2. STS 09, 88.6%, "Advancement of a/b/c Pawns"
3. STS 07, 89.3%, "Offer of Simplification"
4. STS 15, 89.4%, "Avoid Pointless Exchange"
5. STS 03, 90.1%, "Knight Outposts"
```
