### PR TITLE
Assume draw after first repetition

### DIFF
--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -448,12 +448,12 @@ impl Position {
         !self.is_check() && Moves::generate(self, &mut ArrayVec::<_, 0>::new()).is_ok()
     }
 
-    /// Whether the game is a draw by [Threefold repetition].
+    /// Whether the game is a draw by [repetition].
     ///
-    /// [Threefold repetition]: https://en.wikipedia.org/wiki/Threefold_repetition
+    /// [repetition]: https://en.wikipedia.org/wiki/Threefold_repetition
     #[inline(always)]
-    pub fn is_draw_by_threefold_repetition(&self) -> bool {
-        self.repetitions() > 1
+    pub fn is_draw_by_repetition(&self) -> bool {
+        self.repetitions() > 0
     }
 
     /// Whether the game is a draw by the [50-move rule].
@@ -494,10 +494,10 @@ impl Position {
             Some(Outcome::Checkmate(!self.turn()))
         } else if self.is_stalemate() {
             Some(Outcome::Stalemate)
-        } else if self.is_draw_by_threefold_repetition() {
-            Some(Outcome::DrawByThreefoldRepetition)
         } else if self.is_draw_by_50_move_rule() {
             Some(Outcome::DrawBy50MoveRule)
+        } else if self.is_draw_by_repetition() {
+            Some(Outcome::DrawByThreefoldRepetition)
         } else if self.is_material_insufficient() {
             Some(Outcome::DrawByInsufficientMaterial)
         } else {
@@ -967,7 +967,7 @@ mod tests {
         prop_assume!(zobrist.is_some());
 
         pos.history[pos.turn() as usize][..2].clone_from_slice(&[zobrist, zobrist]);
-        assert!(pos.is_draw_by_threefold_repetition());
+        assert!(pos.is_draw_by_repetition());
         assert_eq!(pos.outcome(), Some(Outcome::DrawByThreefoldRepetition));
     }
 


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=5 alpha=0.05 beta=0.05 -games 2 -rounds 10000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 18.04 +/- 8.23, nElo: 28.19 +/- 12.84
LOS: 100.00 %, DrawRatio: 43.35 %, PairsRatio: 1.36
Games: 2814, Wins: 816, Losses: 670, Draws: 1328, Points: 1480.0 (52.59 %)
Ptnml(0-2): [50, 287, 610, 387, 73], WL/DD Ratio: 0.87
LLR: 2.97 (-2.94, 2.94) [0.00, 5.00]
--------------------------------------------------
```

> `fastchess -sprt elo0=0 elo1=5 alpha=0.05 beta=0.05 -games 2 -rounds 10000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=3+0.025`

```
--------------------------------------------------
Results of dev vs base (3+0.025, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 21.15 +/- 8.65, nElo: 36.10 +/- 14.73
LOS: 100.00 %, DrawRatio: 45.46 %, PairsRatio: 1.46
Games: 2138, Wins: 582, Losses: 452, Draws: 1104, Points: 1134.0 (53.04 %)
Ptnml(0-2): [17, 220, 486, 308, 38], WL/DD Ratio: 0.69
LLR: 2.95 (-2.94, 2.94) [0.00, 5.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```

```
