### PR TITLE
Reduce less on transposition miss

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -249,11 +249,8 @@ impl<'a> Search<'a> {
             Some(t) => t.transpose(ply),
         };
 
-        if transposition.is_some() && pos.is_check() {
-            depth += 1;
-        } else if transposition.is_none() && !pos.is_check() {
-            depth -= 2;
-        }
+        depth += pos.is_check() as i8;
+        depth -= transposition.is_none() as i8;
 
         let draft = depth - ply;
         let quiesce = draft <= 0;


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-5 elo1=0 alpha=0.05 beta=0.05 -games 2 -rounds 20000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 2.68 +/- 4.28, nElo: 4.11 +/- 6.56
LOS: 89.03 %, DrawRatio: 40.90 %, PairsRatio: 1.05
Games: 10762, Wins: 2866, Losses: 2783, Draws: 5113, Points: 5422.5 (50.39 %)
Ptnml(0-2): [225, 1330, 2201, 1387, 238], WL/DD Ratio: 0.84
LLR: 2.95 (-2.94, 2.94) [-5.00, 0.00]
--------------------------------------------------
```


### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.3
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:24s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     67     63     65     74     76     55     61     57     52     61     52     54     65     65     46    913
   Score   7834   7266   7761   8369   8351   7607   7386   7172   6217   7326   6475   6682   7082   7471   6453 109452
Score(%)   92.2   90.8   90.2   94.0   98.2   95.1   90.1   89.7   87.6   92.7   92.5   90.3   94.4   94.6   88.4   92.1

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 98.2%, "Bishop vs Knight"
2. STS 06, 95.1%, "Re-Capturing"
3. STS 14, 94.6%, "Queens and Rooks to the 7th rank"
4. STS 13, 94.4%, "Pawn Play in the Center"
5. STS 04, 94.0%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 09, 87.6%, "Advancement of a/b/c Pawns"
2. STS 15, 88.4%, "Avoid Pointless Exchange"
3. STS 08, 89.7%, "Advancement of f/g/h Pawns"
4. STS 07, 90.1%, "Offer of Simplification"
5. STS 03, 90.2%, "Knight Outposts"

```
