### PR TITLE
Remove razoring

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -163,17 +163,6 @@ impl<'a> Search<'a> {
         }
     }
 
-    /// An implementation of [razoring].
-    ///
-    /// [razoring]: https://www.chessprogramming.org/Razoring
-    fn razor(&self, deficit: Score, draft: Depth) -> Option<Depth> {
-        match deficit.get() {
-            ..0 => None,
-            s @ 0..600 => Some(draft - (s + 30) / 210),
-            600.. => Some(draft - 3),
-        }
-    }
-
     /// An implementation of [reverse futility pruning].
     ///
     /// [reverse futility pruning]: https://www.chessprogramming.org/Reverse_Futility_Pruning
@@ -260,12 +249,6 @@ impl<'a> Search<'a> {
 
             if lower >= upper || upper <= alpha || lower >= beta {
                 if !is_pv && t.draft() >= draft {
-                    return Ok(transposed.truncate());
-                }
-            }
-
-            if let Some(d) = self.razor(alpha - upper, draft) {
-                if !is_pv && t.draft() >= d {
                     return Ok(transposed.truncate());
                 }
             }


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.05 -games 2 -rounds 20000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 3.11 +/- 3.52, nElo: 4.87 +/- 5.52
LOS: 95.81 %, DrawRatio: 43.23 %, PairsRatio: 1.06
Games: 15218, Wins: 4083, Losses: 3947, Draws: 7188, Points: 7677.0 (50.45 %)
Ptnml(0-2): [311, 1782, 3289, 1914, 313], WL/DD Ratio: 0.88
LLR: 2.96 (-2.94, 2.94) [-3.00, 1.00]
--------------------------------------------------
```


### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.3
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:26s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     71     63     65     68     71     62     61     58     53     64     55     58     62     60     50    921
   Score   7923   7512   7728   8161   8211   7743   7544   7162   6384   7454   6694   6947   6949   7374   6680 110466
Score(%)   93.2   93.9   89.9   91.7   96.6   96.8   92.0   89.5   89.9   94.4   95.6   93.9   92.7   93.3   91.5   93.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 96.8%, "Re-Capturing"
2. STS 05, 96.6%, "Bishop vs Knight"
3. STS 11, 95.6%, "Activity of the King"
4. STS 10, 94.4%, "Simplification"
5. STS 02, 93.9%, "Open Files and Diagonals"

:: Top 5 STS with low result ::
1. STS 08, 89.5%, "Advancement of f/g/h Pawns"
2. STS 03, 89.9%, "Knight Outposts"
3. STS 09, 89.9%, "Advancement of a/b/c Pawns"
4. STS 15, 91.5%, "Avoid Pointless Exchange"
5. STS 04, 91.7%, "Square Vacancy"
```
