### PR TITLE
Improve null move pruning

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -145,8 +145,8 @@ impl<'a> Search<'a> {
     fn nmp(&self, surplus: Score, draft: Depth) -> Option<Depth> {
         match surplus.get() {
             ..0 => None,
-            s @ 0..20 => Some(draft - (s + 10) / 10 - draft / 4),
-            20.. => Some(draft - 3 - draft / 4),
+            s @ 0..20 => Some(draft - (s + 10) / 10 - draft / 3),
+            20.. => Some(draft - 3 - draft / 3),
         }
     }
 

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -145,8 +145,8 @@ impl<'a> Search<'a> {
     fn nmp(&self, surplus: Score, draft: Depth) -> Option<Depth> {
         match surplus.get() {
             ..0 => None,
-            s @ 0..40 => Some(draft - (s + 20) / 20 - draft / 4),
-            40.. => Some(draft - 3 - draft / 4),
+            s @ 0..20 => Some(draft - (s + 10) / 10 - draft / 4),
+            20.. => Some(draft - 3 - draft / 4),
         }
     }
 


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.05 -games 2 -rounds 25000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 7.64 +/- 4.09, nElo: 11.89 +/- 6.36
LOS: 99.99 %, DrawRatio: 42.17 %, PairsRatio: 1.13
Games: 11462, Wins: 3161, Losses: 2909, Draws: 5392, Points: 5857.0 (51.10 %)
Ptnml(0-2): [215, 1339, 2417, 1499, 261], WL/DD Ratio: 0.89
LLR: 2.96 (-2.94, 2.94) [0.00, 3.00]
--------------------------------------------------
```


### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.3
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:24s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     67     62     64     76     75     63     65     58     55     63     52     59     62     58     52    931
   Score   7800   7347   7602   8573   8230   7651   7554   7104   6470   7380   6509   6907   6917   7243   6809 110096
Score(%)   91.8   91.8   88.4   96.3   96.8   95.6   92.1   88.8   91.1   93.4   93.0   93.3   92.2   91.7   93.3   92.7

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 96.8%, "Bishop vs Knight"
2. STS 04, 96.3%, "Square Vacancy"
3. STS 06, 95.6%, "Re-Capturing"
4. STS 10, 93.4%, "Simplification"
5. STS 12, 93.3%, "Center Control"

:: Top 5 STS with low result ::
1. STS 03, 88.4%, "Knight Outposts"
2. STS 08, 88.8%, "Advancement of f/g/h Pawns"
3. STS 09, 91.1%, "Advancement of a/b/c Pawns"
4. STS 14, 91.7%, "Queens and Rooks to the 7th rank"
5. STS 01, 91.8%, "Undermining"
```
