### PR TITLE
Reduce chance of losing on time

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -519,14 +519,13 @@ impl Engine {
     }
 
     fn time_to_search(&self, pos: &Position, limits: &Limits) -> Range<Duration> {
-        let (clock, inc) = match limits {
-            Limits::Clock(c, i) => (c, i),
-            _ => return limits.time()..limits.time(),
+        let Limits::Clock(clock, inc) = *limits else {
+            return limits.time()..limits.time();
         };
 
-        let time_left = clock.saturating_sub(*inc);
+        let time_left = clock.saturating_sub(inc);
         let moves_left = 256 / pos.fullmoves().get().min(64);
-        let time_per_move = inc.saturating_add(time_left / moves_left);
+        let time_per_move = inc.saturating_add(time_left / moves_left).min(clock / 2);
         time_per_move / 2..time_per_move
     }
 


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.05 -games 2 -rounds 25000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 5.68 +/- 4.47, nElo: 9.31 +/- 7.33
LOS: 99.36 %, DrawRatio: 45.06 %, PairsRatio: 1.11
Games: 8628, Wins: 2305, Losses: 2164, Draws: 4159, Points: 4384.5 (50.82 %)
Ptnml(0-2): [134, 987, 1944, 1102, 147], WL/DD Ratio: 0.88
LLR: 2.94 (-2.94, 2.94) [-3.00, 1.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```

```
