### PR TITLE
Add history bonuses to killer moves

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -292,12 +292,15 @@ impl<'a> Search<'a> {
             .map(|m| {
                 if Some(m) == transposed.head() {
                     return (m, Value::upper());
-                } else if killer.contains(m) {
-                    return (m, Value::new(128));
                 }
 
                 let counter = self.continuation[ply.cast::<usize>() - 1];
-                let rating = pos.gain(m) + self.history.get(pos, m) + counter.get(pos, m);
+                let mut rating = pos.gain(m) + self.history.get(pos, m) + counter.get(pos, m);
+
+                if killer.contains(m) {
+                    rating += 128;
+                }
+
                 (m, rating)
             })
             .collect();


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.05 -games 2 -rounds 25000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 6.57 +/- 3.73, nElo: 10.32 +/- 5.86
LOS: 99.97 %, DrawRatio: 43.34 %, PairsRatio: 1.11
Games: 13490, Wins: 3646, Losses: 3391, Draws: 6453, Points: 6872.5 (50.95 %)
Ptnml(0-2): [244, 1570, 2923, 1703, 305], WL/DD Ratio: 0.84
LLR: 2.96 (-2.94, 2.94) [0.00, 3.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.3
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:26s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     70     65     70     71     70     58     60     61     52     65     53     55     63     63     48    924
   Score   7962   7388   7875   8453   8101   7628   7309   7229   6359   7416   6339   6764   7020   7205   6735 109783
Score(%)   93.7   92.3   91.6   95.0   95.3   95.3   89.1   90.4   89.6   93.9   90.6   91.4   93.6   91.2   92.3   92.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.3%, "Re-Capturing"
2. STS 05, 95.3%, "Bishop vs Knight"
3. STS 04, 95.0%, "Square Vacancy"
4. STS 10, 93.9%, "Simplification"
5. STS 01, 93.7%, "Undermining"

:: Top 5 STS with low result ::
1. STS 07, 89.1%, "Offer of Simplification"
2. STS 09, 89.6%, "Advancement of a/b/c Pawns"
3. STS 08, 90.4%, "Advancement of f/g/h Pawns"
4. STS 11, 90.6%, "Activity of the King"
5. STS 14, 91.2%, "Queens and Rooks to the 7th rank"
```
