### PR TITLE
Print iterative PVs

### DIFF
--- a/benches/search.rs
+++ b/benches/search.rs
@@ -5,18 +5,21 @@ use cinder::search::{Control, Depth, Engine, Limits, Options};
 use cinder::{nnue::Evaluator, util::Integer};
 use criterion::{Criterion, SamplingMode, Throughput};
 use criterion_macro::criterion;
+use futures::executor::block_on_stream;
 use std::thread::available_parallelism;
 use std::time::{Duration, Instant};
 
 fn bench(reps: u64, options: &Options, limits: &Limits) -> Duration {
+    let position = Evaluator::default();
     let mut time = Duration::ZERO;
 
     for _ in 0..reps {
-        let engine = Engine::with_options(options);
-        let pos = Evaluator::default();
-        let ctrl = Control::new(&pos, limits.clone());
+        let mut engine = Engine::with_options(options);
+        let ctrl = Control::new(&position, limits.clone());
+        let search = engine.search(&position, &ctrl);
+
         let timer = Instant::now();
-        engine.search(&pos, &ctrl);
+        block_on_stream(search).for_each(drop);
         time += timer.elapsed();
     }
 

--- a/lib/cinder.rs
+++ b/lib/cinder.rs
@@ -7,6 +7,7 @@
 #![feature(
     array_chunks,
     coverage_attribute,
+    gen_blocks,
     new_zeroed_alloc,
     ptr_as_ref_unchecked,
     round_char_boundary,


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=0 alpha=0.05 beta=0.10 -games 2 -rounds 15000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: -0.55 +/- 2.47, nElo: -0.91 +/- 4.05
LOS: 32.99 %, DrawRatio: 45.91 %, PairsRatio: 0.98
Games: 28206, Wins: 7203, Losses: 7248, Draws: 13755, Points: 14080.5 (49.92 %)
Ptnml(0-2): [445, 3417, 6474, 3272, 495], WL/DD Ratio: 0.83
LLR: 0.41 (-2.25, 2.89) [-3.00, 0.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.3
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:26s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     69     62     70     77     72     57     57     60     49     67     51     51     63     67     50    922
   Score   7940   7255   7965   8562   8032   7604   7252   7295   6167   7588   6474   6597   6912   7624   6571 109838
Score(%)   93.4   90.7   92.6   96.2   94.5   95.0   88.4   91.2   86.9   96.1   92.5   89.1   92.2   96.5   90.0   92.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 14, 96.5%, "Queens and Rooks to the 7th rank"
2. STS 04, 96.2%, "Square Vacancy"
3. STS 10, 96.1%, "Simplification"
4. STS 06, 95.0%, "Re-Capturing"
5. STS 05, 94.5%, "Bishop vs Knight"

:: Top 5 STS with low result ::
1. STS 09, 86.9%, "Advancement of a/b/c Pawns"
2. STS 07, 88.4%, "Offer of Simplification"
3. STS 12, 89.1%, "Center Control"
4. STS 15, 90.0%, "Avoid Pointless Exchange"
5. STS 02, 90.7%, "Open Files and Diagonals"
```
