### PR TITLE
implement time management based on score stability

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -235,7 +235,7 @@ impl<'a> Worker<'a> {
         ply: Ply,
     ) -> Result<Pv<N>, Interrupt> {
         self.nodes.update(1);
-        if self.ctrl.check(self.root, self.pv.head().assume()) == ControlFlow::Abort {
+        if self.ctrl.check(self.root, &self.pv, ply) == ControlFlow::Abort {
             return Err(Interrupt);
         }
 
@@ -395,14 +395,13 @@ impl<'a> Worker<'a> {
         depth: Depth,
     ) -> Result<Pv, Interrupt> {
         let ply = Ply::new(0);
-        let best = self.pv.head().assume();
         let (alpha, beta) = (bounds.start, bounds.end);
-        if self.ctrl.check(self.root, best) != ControlFlow::Continue {
+        if self.ctrl.check(self.root, &self.pv, ply) != ControlFlow::Continue {
             return Err(Interrupt);
         }
 
         for (m, rating) in moves.iter_mut() {
-            if *m == best {
+            if Some(*m) == self.pv.head() {
                 *rating = Value::upper();
             } else {
                 *rating = self.root.gain(*m) + self.history.get(self.root, *m);

--- a/lib/search/limits.rs
+++ b/lib/search/limits.rs
@@ -52,24 +52,6 @@ impl Limits {
             _ => Duration::MAX,
         }
     }
-
-    /// Time left on the clock or [`Duration::MAX`].
-    #[inline(always)]
-    pub fn clock(&self) -> Duration {
-        match self {
-            Limits::Clock(t, _) => *t,
-            _ => Duration::MAX,
-        }
-    }
-
-    /// Time increment or [`Duration::ZERO`].
-    #[inline(always)]
-    pub fn increment(&self) -> Duration {
-        match self {
-            Limits::Clock(_, i) => *i,
-            _ => Duration::ZERO,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -114,31 +96,5 @@ mod tests {
         assert_eq!(Limits::Depth(d).time(), Duration::MAX);
         assert_eq!(Limits::Nodes(n).time(), Duration::MAX);
         assert_eq!(Limits::Clock(t, i).time(), t);
-    }
-
-    #[proptest]
-    fn clock_returns_value_if_set(t: Duration, i: Duration) {
-        assert_eq!(Limits::Clock(t, i).clock(), t);
-    }
-
-    #[proptest]
-    fn clock_returns_max_by_default(d: Depth, n: u64, t: Duration) {
-        assert_eq!(Limits::None.clock(), Duration::MAX);
-        assert_eq!(Limits::Depth(d).clock(), Duration::MAX);
-        assert_eq!(Limits::Nodes(n).clock(), Duration::MAX);
-        assert_eq!(Limits::Time(t).clock(), Duration::MAX);
-    }
-
-    #[proptest]
-    fn increment_returns_value_if_set(t: Duration, i: Duration) {
-        assert_eq!(Limits::Clock(t, i).increment(), i);
-    }
-
-    #[proptest]
-    fn increment_returns_zero_by_default(d: Depth, n: u64, t: Duration) {
-        assert_eq!(Limits::None.increment(), Duration::ZERO);
-        assert_eq!(Limits::Depth(d).increment(), Duration::ZERO);
-        assert_eq!(Limits::Nodes(n).increment(), Duration::ZERO);
-        assert_eq!(Limits::Time(t).increment(), Duration::ZERO);
     }
 }


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 15000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 4.21 +/- 2.85, nElo: 6.73 +/- 4.55
LOS: 99.81 %, DrawRatio: 43.32 %, PairsRatio: 1.07
Games: 22426, Wins: 5974, Losses: 5702, Draws: 10750, Points: 11349.0 (50.61 %)
Ptnml(0-2): [388, 2675, 4858, 2861, 431], WL/DD Ratio: 0.86
LLR: 2.91 (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.4
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:26s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     69     62     69     74     73     56     61     59     48     66     47     56     62     61     48    911
   Score   7844   7409   7927   8517   8123   7668   7468   7153   6186   7520   6252   6894   7024   7371   6481 109837
Score(%)   92.3   92.6   92.2   95.7   95.6   95.8   91.1   89.4   87.1   95.2   89.3   93.2   93.7   93.3   88.8   92.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.8%, "Re-Capturing"
2. STS 04, 95.7%, "Square Vacancy"
3. STS 05, 95.6%, "Bishop vs Knight"
4. STS 10, 95.2%, "Simplification"
5. STS 13, 93.7%, "Pawn Play in the Center"

:: Top 5 STS with low result ::
1. STS 09, 87.1%, "Advancement of a/b/c Pawns"
2. STS 15, 88.8%, "Avoid Pointless Exchange"
3. STS 11, 89.3%, "Activity of the King"
4. STS 08, 89.4%, "Advancement of f/g/h Pawns"
5. STS 07, 91.1%, "Offer of Simplification"
```
