### PR TITLE
Improve SIMD implementation of NNUE inference

### DIFF
--- a/lib/nnue/hidden.rs
+++ b/lib/nnue/hidden.rs
@@ -1,5 +1,4 @@
 use crate::util::AlignTo64;
-use std::ops::Shl;
 
 /// The hidden layer.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -21,43 +20,34 @@ impl<const N: usize> Hidden<N> {
         use std::{arch::x86_64::*, mem::transmute};
 
         #[inline(always)]
-        unsafe fn sqrcrelu(p: __m256i, q: __m256i) -> __m256i {
+        unsafe fn dot(a: __m128i, x: __m256i, y: __m256i) -> __m256i {
             unsafe {
-                let r = _mm256_packus_epi16(p, q);
-                let p = _mm256_unpacklo_epi8(r, _mm256_setzero_si256());
-                let q = _mm256_unpackhi_epi8(r, _mm256_setzero_si256());
-                let p = _mm256_slli_epi16(p, 3);
-                let q = _mm256_slli_epi16(q, 3);
-                let p = _mm256_mulhrs_epi16(p, p);
-                let q = _mm256_mulhrs_epi16(q, q);
-                let r = _mm256_packus_epi16(p, q);
-                _mm256_permute4x64_epi64(r, _MM_SHUFFLE(3, 1, 2, 0))
-            }
-        }
-
-        #[inline(always)]
-        unsafe fn dot(p: __m256i, q: __m256i, r: __m256i) -> __m256i {
-            unsafe {
-                let s = _mm256_maddubs_epi16(p, q);
-                _mm256_add_epi32(r, _mm256_madd_epi16(s, _mm256_set1_epi16(1)))
+                let x = _mm256_max_epi16(x, _mm256_setzero_si256());
+                let x = _mm256_min_epi16(x, _mm256_set1_epi16(255));
+                let p = _mm256_mullo_epi16(x, _mm256_cvtepi8_epi16(a));
+                _mm256_add_epi32(y, _mm256_madd_epi16(x, p))
             }
         }
 
         unsafe {
-            let mut y = _mm256_setr_epi32(self.bias, 0, 0, 0, 0, 0, 0, 0);
+            let mut y = _mm256_setzero_si256();
 
-            for (w, i) in self.weight.iter().zip([us, them]) {
+            for (w, x) in self.weight.iter().zip([us, them]) {
                 (w.as_ptr() as usize % 32 == 0).assume();
-                (i.as_ptr() as usize % 32 == 0).assume();
+                (x.as_ptr() as usize % 32 == 0).assume();
 
-                for (a, x) in Iterator::zip(w.array_chunks::<128>(), i.array_chunks::<128>()) {
-                    let a = transmute::<&[i8; 128], &[__m256i; 4]>(a);
-                    let x = transmute::<&[i16; 128], &[[__m256i; 2]; 4]>(x);
+                for (w, x) in Iterator::zip(w.array_chunks::<128>(), x.array_chunks::<128>()) {
+                    let w = transmute::<&[i8; 128], &[__m128i; 8]>(w);
+                    let x = transmute::<&[i16; 128], &[__m256i; 8]>(x);
 
-                    y = dot(sqrcrelu(x[0][0], x[0][1]), a[0], y);
-                    y = dot(sqrcrelu(x[1][0], x[1][1]), a[1], y);
-                    y = dot(sqrcrelu(x[2][0], x[2][1]), a[2], y);
-                    y = dot(sqrcrelu(x[3][0], x[3][1]), a[3], y);
+                    y = dot(w[0], x[0], y);
+                    y = dot(w[1], x[1], y);
+                    y = dot(w[2], x[2], y);
+                    y = dot(w[3], x[3], y);
+                    y = dot(w[4], x[4], y);
+                    y = dot(w[5], x[5], y);
+                    y = dot(w[6], x[6], y);
+                    y = dot(w[7], x[7], y);
                 }
             }
 
@@ -69,7 +59,7 @@ impl<const N: usize> Hidden<N> {
             let r = _mm_add_epi32(r, s);
             let s = _mm_shuffle_epi32(r, _MM_SHUFFLE(2, 3, 0, 1));
             let r = _mm_add_epi32(r, s);
-            _mm_extract_epi32(r, 0)
+            self.bias + (_mm_extract_epi32(r, 0) >> 9)
         }
     }
 
@@ -83,42 +73,34 @@ impl<const N: usize> Hidden<N> {
         use std::{arch::x86_64::*, mem::transmute};
 
         #[inline(always)]
-        unsafe fn sqrcrelu(p: __m128i, q: __m128i) -> __m128i {
+        unsafe fn dot(a: __m128i, x: __m128i, y: __m128i) -> __m128i {
             unsafe {
-                let r = _mm_packus_epi16(p, q);
-                let p = _mm_unpacklo_epi8(r, _mm_setzero_si128());
-                let q = _mm_unpackhi_epi8(r, _mm_setzero_si128());
-                let p = _mm_slli_epi16(p, 3);
-                let q = _mm_slli_epi16(q, 3);
-                let p = _mm_mulhrs_epi16(p, p);
-                let q = _mm_mulhrs_epi16(q, q);
-                _mm_packus_epi16(p, q)
-            }
-        }
-
-        #[inline(always)]
-        unsafe fn dot(p: __m128i, q: __m128i, r: __m128i) -> __m128i {
-            unsafe {
-                let s = _mm_maddubs_epi16(p, q);
-                _mm_add_epi32(r, _mm_madd_epi16(s, _mm_set1_epi16(1)))
+                let x = _mm_max_epi16(x, _mm_setzero_si128());
+                let x = _mm_min_epi16(x, _mm_set1_epi16(255));
+                let p = _mm_mullo_epi16(x, _mm_cvtepi8_epi16(a));
+                _mm_add_epi32(y, _mm_madd_epi16(x, p))
             }
         }
 
         unsafe {
-            let mut y = _mm_setr_epi32(self.bias, 0, 0, 0);
+            let mut y = _mm_setzero_si128();
 
-            for (w, i) in self.weight.iter().zip([us, them]) {
-                (w.as_ptr() as usize % 16 == 0).assume();
-                (i.as_ptr() as usize % 16 == 0).assume();
+            for (w, x) in self.weight.iter().zip([us, them]) {
+                (w.as_ptr() as usize % 32 == 0).assume();
+                (x.as_ptr() as usize % 32 == 0).assume();
 
-                for (a, x) in Iterator::zip(w.array_chunks::<64>(), i.array_chunks::<64>()) {
-                    let a = transmute::<&[i8; 64], &[__m128i; 4]>(a);
-                    let x = transmute::<&[i16; 64], &[[__m128i; 2]; 4]>(x);
+                for (w, x) in Iterator::zip(w.array_chunks::<64>(), x.array_chunks::<64>()) {
+                    let w = transmute::<&[i8; 64], &[u64; 8]>(w);
+                    let x = transmute::<&[i16; 64], &[__m128i; 8]>(x);
 
-                    y = dot(sqrcrelu(x[0][0], x[0][1]), a[0], y);
-                    y = dot(sqrcrelu(x[1][0], x[1][1]), a[1], y);
-                    y = dot(sqrcrelu(x[2][0], x[2][1]), a[2], y);
-                    y = dot(sqrcrelu(x[3][0], x[3][1]), a[3], y);
+                    y = dot(_mm_loadu_si64(&w[0] as *const u64 as *const _), x[0], y);
+                    y = dot(_mm_loadu_si64(&w[1] as *const u64 as *const _), x[1], y);
+                    y = dot(_mm_loadu_si64(&w[2] as *const u64 as *const _), x[2], y);
+                    y = dot(_mm_loadu_si64(&w[3] as *const u64 as *const _), x[3], y);
+                    y = dot(_mm_loadu_si64(&w[4] as *const u64 as *const _), x[4], y);
+                    y = dot(_mm_loadu_si64(&w[5] as *const u64 as *const _), x[5], y);
+                    y = dot(_mm_loadu_si64(&w[6] as *const u64 as *const _), x[6], y);
+                    y = dot(_mm_loadu_si64(&w[7] as *const u64 as *const _), x[7], y);
                 }
             }
 
@@ -127,7 +109,7 @@ impl<const N: usize> Hidden<N> {
             let s = _mm_add_epi32(r, y);
             let r = _mm_shufflelo_epi16(s, _MM_SHUFFLE(1, 0, 3, 2));
             let s = _mm_add_epi32(r, s);
-            _mm_cvtsi128_si32(s)
+            self.bias + (_mm_cvtsi128_si32(s) >> 9)
         }
     }
 
@@ -141,56 +123,56 @@ impl<const N: usize> Hidden<N> {
         use std::{arch::aarch64::*, mem::transmute};
 
         #[inline(always)]
-        unsafe fn sqrcrelu(p: int16x8_t, q: int16x8_t) -> uint8x16_t {
+        unsafe fn dot(a: int8x8_t, x: int16x8_t, y: int32x4_t) -> int32x4_t {
             unsafe {
-                let p = vmovl_u8(vqmovun_s16(p));
-                let q = vmovl_u8(vqmovun_s16(q));
-                let p = transmute(vshlq_u16(p, vdupq_n_s16(3)));
-                let q = transmute(vshlq_u16(q, vdupq_n_s16(3)));
-                let p = vqrdmulhq_s16(p, p);
-                let q = vqrdmulhq_s16(q, q);
-                vcombine_u8(vqmovun_s16(p), vqmovun_s16(q))
-            }
-        }
+                let x = vmaxq_s16(x, vdupq_n_s16(0));
+                let x = vminq_s16(x, vdupq_n_s16(255));
+                let p = vmulq_s16(x, vmovl_s8(a));
 
-        #[inline(always)]
-        unsafe fn dot(p: uint8x16_t, q: int8x16_t, r: int32x4_t) -> int32x4_t {
-            unsafe { vdotq_s32(r, transmute(p), q) }
+                vpaddq_s32(
+                    vmull_s16(vget_low_s16(x), vget_low_s16(p)),
+                    vmlal_high_s16(y, x, p),
+                )
+            }
         }
 
         unsafe {
-            let mut y = vld1q_s32([self.bias, 0, 0, 0].as_ptr());
+            let mut y = vdupq_n_s32(0);
 
-            for (w, i) in self.weight.iter().zip([us, them]) {
-                (w.as_ptr() as usize % 16 == 0).assume();
-                (i.as_ptr() as usize % 16 == 0).assume();
+            for (w, x) in self.weight.iter().zip([us, them]) {
+                (w.as_ptr() as usize % 32 == 0).assume();
+                (x.as_ptr() as usize % 32 == 0).assume();
 
-                for (a, x) in Iterator::zip(w.array_chunks::<64>(), i.array_chunks::<64>()) {
-                    let a = transmute::<&[i8; 64], &[int8x16_t; 4]>(a);
-                    let x = transmute::<&[i16; 64], &[[int16x8_t; 2]; 4]>(x);
+                for (w, x) in Iterator::zip(w.array_chunks::<64>(), x.array_chunks::<64>()) {
+                    let w = transmute::<&[i8; 64], &[int8x8_t; 8]>(w);
+                    let x = transmute::<&[i16; 64], &[int16x8_t; 8]>(x);
 
-                    y = dot(sqrcrelu(x[0][0], x[0][1]), a[0], y);
-                    y = dot(sqrcrelu(x[1][0], x[1][1]), a[1], y);
-                    y = dot(sqrcrelu(x[2][0], x[2][1]), a[2], y);
-                    y = dot(sqrcrelu(x[3][0], x[3][1]), a[3], y);
+                    y = dot(w[0], x[0], y);
+                    y = dot(w[1], x[1], y);
+                    y = dot(w[2], x[2], y);
+                    y = dot(w[3], x[3], y);
+                    y = dot(w[4], x[4], y);
+                    y = dot(w[5], x[5], y);
+                    y = dot(w[6], x[6], y);
+                    y = dot(w[7], x[7], y);
                 }
             }
 
-            vaddvq_s32(y)
+            self.bias + (vaddvq_s32(y) >> 9)
         }
     }
 
     #[doc(hidden)]
     #[inline(always)]
     pub fn scalar(&self, us: &[i16; N], them: &[i16; N]) -> i32 {
-        let mut y = self.bias;
-        for (w, i) in self.weight.iter().zip([us, them]) {
-            for (&a, &x) in Iterator::zip(w.iter(), i.iter()) {
-                y += a as i32 * (((x as i32).clamp(0, 255).shl(3i32).pow(2) + 16384) >> 15);
+        let mut y = 0;
+        for (w, x) in self.weight.iter().zip([us, them]) {
+            for (&w, &x) in Iterator::zip(w.iter(), x.iter()) {
+                y += w as i32 * (x as i32).clamp(0, 255).pow(2);
             }
         }
 
-        y
+        self.bias + (y >> 9)
     }
 }
 


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 15000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 6.60 +/- 3.73, nElo: 10.62 +/- 6.01
LOS: 99.97 %, DrawRatio: 44.47 %, PairsRatio: 1.13
Games: 12846, Wins: 3408, Losses: 3164, Draws: 6274, Points: 6545.0 (50.95 %)
Ptnml(0-2): [219, 1457, 2856, 1643, 248], WL/DD Ratio: 0.80
LLR: 2.91 (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.4
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:26s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     70     61     66     74     74     56     63     55     55     63     53     55     64     63     51    923
   Score   7810   7219   7712   8451   8288   7614   7459   7046   6423   7470   6573   6814   7083   7337   6670 109969
Score(%)   91.9   90.2   89.7   95.0   97.5   95.2   91.0   88.1   90.5   94.6   93.9   92.1   94.4   92.9   91.4   92.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 97.5%, "Bishop vs Knight"
2. STS 06, 95.2%, "Re-Capturing"
3. STS 04, 95.0%, "Square Vacancy"
4. STS 10, 94.6%, "Simplification"
5. STS 13, 94.4%, "Pawn Play in the Center"

:: Top 5 STS with low result ::
1. STS 08, 88.1%, "Advancement of f/g/h Pawns"
2. STS 03, 89.7%, "Knight Outposts"
3. STS 02, 90.2%, "Open Files and Diagonals"
4. STS 09, 90.5%, "Advancement of a/b/c Pawns"
5. STS 07, 91.0%, "Offer of Simplification"
```
