### PR TITLE
Reintroduce razoring

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -148,6 +148,17 @@ impl<'a> Searcher<'a> {
         }
     }
 
+    /// An implementation of [razoring].
+    ///
+    /// [razoring]: https://www.chessprogramming.org/Razoring
+    fn razor(&self, deficit: Score, draft: Depth) -> Option<Depth> {
+        match deficit.get() {
+            ..0 => None,
+            s @ 0..900 => Some(draft - (s + 180) / 360),
+            900.. => Some(draft - 3),
+        }
+    }
+
     /// An implementation of [late move reductions].
     ///
     /// [late move reductions]: https://www.chessprogramming.org/Late_Move_Reductions
@@ -234,6 +245,12 @@ impl<'a> Searcher<'a> {
             }
 
             if let Some(d) = self.rfp(lower - beta, draft) {
+                if !is_pv && t.draft() >= d {
+                    return Ok(transposed.truncate());
+                }
+            }
+
+            if let Some(d) = self.razor(alpha - upper, draft) {
                 if !is_pv && t.draft() >= d {
                     return Ok(transposed.truncate());
                 }


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 20000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 12.09 +/- 5.30, nElo: 18.92 +/- 8.28
LOS: 100.00 %, DrawRatio: 42.17 %, PairsRatio: 1.22
Games: 6758, Wins: 1887, Losses: 1652, Draws: 3219, Points: 3496.5 (51.74 %)
Ptnml(0-2): [116, 764, 1425, 917, 157], WL/DD Ratio: 0.85
LLR: 2.91 (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.4
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:25s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     69     63     70     77     76     60     63     57     53     65     53     57     65     66     49    943
   Score   7885   7245   7922   8637   8194   7744   7503   7188   6247   7426   6359   6770   7197   7559   6536 110412
Score(%)   92.8   90.6   92.1   97.0   96.4   96.8   91.5   89.8   88.0   94.0   90.8   91.5   96.0   95.7   89.5   92.9

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 04, 97.0%, "Square Vacancy"
2. STS 06, 96.8%, "Re-Capturing"
3. STS 05, 96.4%, "Bishop vs Knight"
4. STS 13, 96.0%, "Pawn Play in the Center"
5. STS 14, 95.7%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 09, 88.0%, "Advancement of a/b/c Pawns"
2. STS 15, 89.5%, "Avoid Pointless Exchange"
3. STS 08, 89.8%, "Advancement of f/g/h Pawns"
4. STS 02, 90.6%, "Open Files and Diagonals"
5. STS 11, 90.8%, "Activity of the King"
```
