### PR TITLE
Isolate History and Continuation tables per thread

### DIFF
--- a/lib/search/continuation.rs
+++ b/lib/search/continuation.rs
@@ -38,12 +38,12 @@ impl Statistics for Reply {
 
 #[derive(Debug)]
 #[debug("Continuation")]
-pub struct Continuation(Box<[[[Reply; 6]; 64]; 12]>);
+pub struct Continuation([[[Reply; 6]; 64]; 12]);
 
 impl Default for Continuation {
     #[inline(always)]
     fn default() -> Self {
-        Self(unsafe { Box::new_zeroed().assume_init() })
+        Self(unsafe { MaybeUninit::zeroed().assume_init() })
     }
 }
 

--- a/lib/search/statistics.rs
+++ b/lib/search/statistics.rs
@@ -135,17 +135,3 @@ impl Stat for Graviton {
         result.assume();
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fmt::Debug;
-    use test_strategy::proptest;
-
-    #[proptest]
-    fn counter_accumulates_value(c: Counter, d: u8) {
-        let prev = c.get();
-        c.update(d as usize);
-        assert_eq!(c.get(), prev + d as usize);
-    }
-}


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=0 alpha=0.05 beta=0.10 -games 2 -rounds 20000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 1.70 +/- 2.51, nElo: 2.83 +/- 4.15
LOS: 90.89 %, DrawRatio: 46.92 %, PairsRatio: 1.03
Games: 26900, Wins: 7051, Losses: 6919, Draws: 12930, Points: 13516.0 (50.25 %)
Ptnml(0-2): [423, 3100, 6311, 3154, 462], WL/DD Ratio: 0.89
LLR: 2.89 (-2.25, 2.89) [-3.00, 0.00]
--------------------------------------------------
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.4
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:26s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     69     63     68     74     75     60     67     57     56     68     53     58     63     63     49    943
   Score   7996   7281   7913   8471   8364   7778   7783   7098   6610   7519   6406   6885   7026   7398   6592 111120
Score(%)   94.1   91.0   92.0   95.2   98.4   97.2   94.9   88.7   93.1   95.2   91.5   93.0   93.7   93.6   90.3   93.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 98.4%, "Bishop vs Knight"
2. STS 06, 97.2%, "Re-Capturing"
3. STS 04, 95.2%, "Square Vacancy"
4. STS 10, 95.2%, "Simplification"
5. STS 07, 94.9%, "Offer of Simplification"

:: Top 5 STS with low result ::
1. STS 08, 88.7%, "Advancement of f/g/h Pawns"
2. STS 15, 90.3%, "Avoid Pointless Exchange"
3. STS 02, 91.0%, "Open Files and Diagonals"
4. STS 11, 91.5%, "Activity of the King"
5. STS 03, 92.0%, "Knight Outposts"
```
