### PR TITLE
Implement Static Exchange Evaluation

### DIFF
--- a/lib/nnue/accumulator.rs
+++ b/lib/nnue/accumulator.rs
@@ -19,8 +19,8 @@ impl Default for Accumulator {
     #[inline(always)]
     fn default() -> Self {
         Accumulator {
-            material: AlignTo64([Nnue::psqt().fresh(); 2]),
-            positional: AlignTo64([Nnue::ft().fresh(); 2]),
+            material: AlignTo64([Nnue::material().fresh(); 2]),
+            positional: AlignTo64([Nnue::positional().fresh(); 2]),
         }
     }
 }
@@ -31,31 +31,34 @@ impl Accumulator {
 
     #[inline(always)]
     pub fn refresh(&mut self, side: Color) {
-        self.material[side as usize] = Nnue::psqt().fresh();
-        self.positional[side as usize] = Nnue::ft().fresh();
+        self.material[side as usize] = Nnue::material().fresh();
+        self.positional[side as usize] = Nnue::positional().fresh();
     }
 
     #[inline(always)]
     pub fn update(&mut self, side: Color, sub: [Option<Feature>; 2], add: [Option<Feature>; 2]) {
+        let material = Nnue::material();
+        let positional = Nnue::positional();
+
         match (sub, add) {
             ([None, None], [Some(a1), None]) => {
-                Nnue::psqt().add(a1, &mut self.material[side as usize]);
-                Nnue::ft().add(a1, &mut self.positional[side as usize]);
+                material.add(a1, &mut self.material[side as usize]);
+                positional.add(a1, &mut self.positional[side as usize]);
             }
 
             ([Some(s1), None], [Some(a1), None]) => {
-                Nnue::psqt().sub_add(s1, a1, &mut self.material[side as usize]);
-                Nnue::ft().sub_add(s1, a1, &mut self.positional[side as usize]);
+                material.sub_add(s1, a1, &mut self.material[side as usize]);
+                positional.sub_add(s1, a1, &mut self.positional[side as usize]);
             }
 
             ([Some(s1), Some(s2)], [Some(a1), None]) => {
-                Nnue::psqt().sub_sub_add(s1, s2, a1, &mut self.material[side as usize]);
-                Nnue::ft().sub_sub_add(s1, s2, a1, &mut self.positional[side as usize]);
+                material.sub_sub_add(s1, s2, a1, &mut self.material[side as usize]);
+                positional.sub_sub_add(s1, s2, a1, &mut self.positional[side as usize]);
             }
 
             ([Some(s1), Some(s2)], [Some(a1), Some(a2)]) => {
-                Nnue::psqt().sub_sub_add_add(s1, s2, a1, a2, &mut self.material[side as usize]);
-                Nnue::ft().sub_sub_add_add(s1, s2, a1, a2, &mut self.positional[side as usize]);
+                material.sub_sub_add_add(s1, s2, a1, a2, &mut self.material[side as usize]);
+                positional.sub_sub_add_add(s1, s2, a1, a2, &mut self.positional[side as usize]);
             }
 
             _ => unsafe { unreachable_unchecked() },

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -104,43 +104,24 @@ impl Evaluator {
 
     /// Estimates the material gain of a move.
     pub fn gain(&self, m: Move) -> Value {
-        if m.is_quiet() {
-            return Value::new(0);
-        }
+        let mut score = 0;
 
-        let psqt = Nnue::psqt();
-        let turn = self.turn();
-        let promotion = m.promotion();
-        let (wc, wt) = (m.whence(), m.whither());
-        let role = self[wc].assume().role();
-        let phase = (self.occupied().len() - 1 - m.is_capture() as usize) / 4;
-        let mut deltas = [0i32, 0i32];
+        if !m.is_quiet() {
+            let pieces = Nnue::pieces((self.occupied().len() - 1) / 4);
 
-        for (delta, side) in deltas.iter_mut().zip([turn, !turn]) {
-            let ksq = self.king(side);
+            if let Some(victim) = self[m.whither()] {
+                score += pieces[victim.role().cast::<usize>()];
+            } else if m.is_capture() {
+                score += pieces[Role::Pawn.cast::<usize>()];
+            }
 
-            let old = Feature::new(side, ksq, Piece::new(role, turn), wc);
-            *delta -= psqt.get(old.cast::<usize>()).assume().get(phase).assume();
-
-            let new = Feature::new(side, ksq, Piece::new(promotion.unwrap_or(role), turn), wt);
-            *delta += psqt.get(new.cast::<usize>()).assume().get(phase).assume();
-
-            if m.is_capture() {
-                let (victim, target) = match self[wt] {
-                    Some(p) => (p, wt),
-                    None => (
-                        Piece::new(Role::Pawn, !turn),
-                        Square::new(wt.file(), wc.rank()),
-                    ),
-                };
-
-                let cap = Feature::new(side, ksq, victim, target);
-                *delta -= psqt.get(cap.cast::<usize>()).assume().get(phase).assume();
+            if let Some(promotion) = m.promotion() {
+                score += pieces[promotion.cast::<usize>()];
+                score -= pieces[Role::Pawn.cast::<usize>()];
             }
         }
 
-        let value = (deltas[0] - deltas[1]) / 128;
-        value.saturate()
+        (score / 128).saturate()
     }
 
     /// Whether this move wins the exchange by at least `margin`.
@@ -150,31 +131,19 @@ impl Evaluator {
 
     /// Computes the static exchange evaluation.
     pub fn see(&self, m: Move, bounds: Range<Value>) -> Value {
-        let phase = (self.occupied().len() - 1) / 4;
-        let pt = Nnue::pt(phase).map(|v| v / 128);
-
-        let mut score = Value::new(0);
+        let mut score = self.gain(m);
         let (mut alpha, mut beta) = (bounds.start, bounds.end);
-
-        if let Some(victim) = self[m.whither()] {
-            score += pt[victim.role().cast::<usize>()];
-        } else if m.is_capture() {
-            score += pt[Role::Pawn.cast::<usize>()];
-        }
-
-        if let Some(promotion) = m.promotion() {
-            score += pt[promotion.cast::<usize>()] - pt[Role::Pawn.cast::<usize>()];
-        }
-
         beta = beta.min(score);
 
         if alpha >= beta {
             return alpha;
         }
 
+        let pieces = Nnue::pieces((self.occupied().len() - 1) / 4);
+
         score -= match m.promotion() {
-            None => pt[self[m.whence()].assume().role().cast::<usize>()],
-            Some(promotion) => pt[promotion.cast::<usize>()],
+            None => pieces[self[m.whence()].assume().role().cast::<usize>()] / 128,
+            Some(promotion) => pieces[promotion.cast::<usize>()] / 128,
         };
 
         alpha = alpha.max(score);
@@ -186,22 +155,22 @@ impl Evaluator {
         let mut exchanges = self.exchanges(m);
 
         loop {
-            let Some((_, capture, _)) = exchanges.next() else {
+            let Some((_, captor, _)) = exchanges.next() else {
                 break beta;
             };
 
-            score = -(score + pt[capture.cast::<usize>()]);
+            score = -(score + pieces[captor.cast::<usize>()] / 128);
             beta = beta.min(-score);
 
             if alpha >= beta {
                 break alpha;
             }
 
-            let Some((_, capture, _)) = exchanges.next() else {
+            let Some((_, captor, _)) = exchanges.next() else {
                 break alpha;
             };
 
-            score = -(score + pt[capture.cast::<usize>()]);
+            score = -(score + pieces[captor.cast::<usize>()] / 128);
             alpha = alpha.max(score);
 
             if alpha >= beta {
@@ -258,74 +227,74 @@ mod tests {
 
     #[rustfmt::skip]
     const SEE_SUITE: &[(&str, &str, i16)] = &[
-        ("r1bq1r2/pp1ppkbp/4N1p1/n3P1B1/8/2N5/PPP2PPP/R2QK2R w KQ - 0 1", "e6g7", 29),
-        ("r4k2/p2P2pp/8/1pb5/1Nn1P1n1/6Q1/PPP4P/R3K1NR w KQ - 0 1", "d7d8q", -48),
-        ("rnbqrbn1/pp3ppp/3p4/2p2k2/4p3/3B1K2/PPP2PPP/RNB1Q1NR w - - 0 1", "d3e4", 48),
-        ("8/pp6/2pkp3/4bp2/2R3b1/2P5/PP4B1/1K6 w - - 0 1", "g2c6", -172),
-        ("6rr/6pk/p1Qp1b1p/2n5/1B3p2/5p2/P1P2P2/4RK1R w - - 0 1", "e1e8", -307),
-        ("2r1r1k1/pp1bppbp/3p1np1/q3P3/2P2P2/1P2B3/P1N1B1PP/2RQ1RK1 b - - 0 1", "d6e5", 48),
-        ("8/8/8/1k6/6b1/4N3/2p3K1/3n4 w - - 0 1", "e3d1", 0),
-        ("7r/5qpk/p1Qp1b1p/3r3n/BB3p2/5p2/P1P2P2/4RK1R w - - 0 1", "e1e8", 0),
-        ("6k1/1pp4p/p1pb4/6q1/3P1pRr/2P4P/PP1Br1P1/5RKN w - - 0 1", "f1f4", -39),
-        ("6RR/4bP2/8/8/5r2/3K4/5p2/4k3 w - - 0 1", "f7f8n", 143),
-        ("5k2/p2P2pp/1b6/1p6/1Nn1P1n1/8/PPP4P/R2QK1NR w KQ - 0 1", "d7d8q", 172),
-        ("4kbnr/p1P4p/b1q5/5pP1/4n2Q/8/PP1PPP1P/RNB1KBNR w KQk f6 0 1", "g5f6", 0),
-        ("4kbnr/p1P1pppp/b7/4q3/7n/8/PP1PPPPP/RNBQKBNR w KQk - 0 1", "c7c8q", -48),
-        ("r1bq1r2/pp1ppkbp/4N1pB/n3P3/8/2N5/PPP2PPP/R2QK2R w KQ - 0 1", "e6g7", 220),
-        ("r2q1rk1/1b2bppp/p2p1n2/1ppNp3/3nP3/P2P1N1P/BPP2PP1/R1BQR1K1 w - - 0 1", "d5e7", 29),
-        ("4kbnr/p1P1pppp/b7/4q3/7n/8/PPQPPPPP/RNB1KBNR w KQk - 0 1", "c7c8q", 172),
-        ("2r1k3/pbr3pp/5p1b/2KB3n/1N2N3/3P1PB1/PPP1P1PP/R2Q3R w - - 0 1", "d5c6", -191),
-        ("rn2k2r/1bq2ppp/p2bpn2/1p1p4/3N4/1BN1P3/PPP2PPP/R1BQR1K1 b kq - 0 1", "d6h2", 48),
-        ("3r3k/3r4/2n1n3/8/3p4/2PR4/1B1Q4/3R3K w - - 0 1", "d3d4", -116),
-        ("5rk1/5pp1/2r4p/5b2/2R5/6Q1/R1P1qPP1/5NK1 b - - 0 1", "f5c2", -172),
-        ("3n3r/2P5/8/1k6/8/8/3Q4/4K3 w - - 0 1", "c7d8q", 450),
-        ("1r3r2/5p2/4p2p/4n1P1/kPPN1nP1/5P2/8/2KR1B1R b - - 0 1", "b8b4", 48),
-        ("2r4k/2r4p/p7/2b2p1b/4pP2/1BR5/P1R3PP/2Q4K w - - 0 1", "c3c5", 220),
-        ("8/4kp2/2npp3/1Nn5/1p2P1P1/7q/1PP1B3/4KR1r b - - 0 1", "h1f1", 0),
-        ("rnbq1rk1/pppp1ppp/4pn2/8/1bPP4/P1N5/1PQ1PPPP/R1B1KBNR b KQ - 0 1", "b4c3", -29),
-        ("rnb2b1r/ppp2kpp/5n2/4P3/q2P3B/5R2/PPP2PPP/RN1QKB2 w Q - 0 1", "h4f6", 19),
-        ("8/4kp2/2npp3/1Nn5/1p2PQP1/7q/1PP1B3/4KR1r b - - 0 1", "h1f1", 0),
-        ("2r2r1k/6bp/p7/2q2p1Q/3PpP2/1B6/P5PP/2RR3K b - - 0 1", "c5c1", 0),
-        ("1r5k/p4pp1/2p1p2p/qpQP3P/2P2P2/1P1R4/P4rP1/1K1R4 b - - 0 1", "a5a2", 48),
-        ("1r3r1k/p4pp1/2p1p2p/qpQP3P/2P5/3R4/PP3PP1/1K1R4 b - - 0 1", "a5a2", -566),
-        ("rnbqk2r/pp3ppp/2p1pn2/3p4/3P4/N1P1BN2/PPB1PPPb/R2Q1RK1 w kq - 0 1", "g1h2", 220),
-        ("7R/4bP2/8/8/1q6/3K4/5p2/4k3 w - - 0 1", "f7f8r", -48),
-        ("4R3/2r3p1/5bk1/1p1r1p1p/p2PR1P1/P1BK1P2/1P6/8 b - - 0 1", "h5g4", 0),
-        ("8/8/1k6/8/8/2N1N3/4p1K1/3n4 w - - 0 1", "c3d1", 48),
-        ("r2q1rk1/2p1bppp/p2p1n2/1p2P3/4P1b1/1nP1BN2/PP3PPP/RN1QR1K1 b - - 0 1", "g4f3", -29),
-        ("4kbnr/p1P4p/b1q5/5pP1/4n3/5Q2/PP1PPP1P/RNB1KBNR w KQk f6 0 1", "g5f6", 0),
-        ("r2qkbn1/ppp1pp1p/3p1rp1/3Pn3/4P1b1/2N2N2/PPP2PPP/R1BQKB1R b KQq - 0 1", "g4f3", 19),
-        ("2r4r/1P4pk/p2p1b1p/7n/BB3p2/2R2p2/P1P2P2/4RK2 w - - 0 1", "c3c8", 307),
-        ("rnq1k2r/1b3ppp/p2bpn2/1p1p4/3N4/1BN1P3/PPP2PPP/R1BQR1K1 b kq - 0 1", "d6h2", -172),
-        ("4q3/1p1pr1kb/1B2rp2/6p1/p3PP2/P3R1P1/1P2R1K1/4Q3 b - - 0 1", "h7e4", 48),
-        ("6r1/4kq2/b2p1p2/p1pPb3/p1P2B1Q/2P4P/2B1R1P1/6K1 w - - 0 1", "f4e5", 0),
-        ("6RR/4bP2/8/8/5r2/3K4/5p2/4k3 w - - 0 1", "f7f8q", 172),
-        ("3q2nk/pb1r1p2/np6/3P2Pp/2p1P3/2R1B2B/PQ3P1P/3R2K1 w - h6 0 1", "g5h6", 48),
+        ("1k1r3q/1ppn3p/p4b2/4p3/8/P2N2P1/1PP1R1BP/2K1Q3 w - - 0 1", "d3e5", -130),
+        ("1k1r4/1ppn3p/p4b2/4n3/8/P2N2P1/1PP1R1BP/2K1Q3 w - - 0 1", "d3e5", 69),
+        ("1n2kb1r/p1P4p/2qb4/5pP1/4n2Q/8/PP1PPP1P/RNB1KBNR w KQk - 0 1", "c7b8q", 125),
+        ("1r3r1k/p4pp1/2p1p2p/qpQP3P/2P5/3R4/PP3PP1/1K1R4 b - - 0 1", "a5a2", -564),
+        ("1r3r2/5p2/4p2p/2k1n1P1/2PN1nP1/1P3P2/8/2KR1B1R b - - 0 1", "b8b3", -275),
+        ("1r3r2/5p2/4p2p/4n1P1/kPPN1nP1/5P2/8/2KR1B1R b - - 0 1", "b8b4", 59),
+        ("1r5k/p4pp1/2p1p2p/qpQP3P/2P2P2/1P1R4/P4rP1/1K1R4 b - - 0 1", "a5a2", 56),
         ("2r1k2r/pb4pp/5p1b/2KB3n/1N2N3/3P1PB1/PPP1P1PP/R2Q3R w k - 0 1", "d5c6", 0),
-        ("4r1k1/5pp1/nbp4p/1p2p2q/1P2P1b1/1BP2N1P/1B2QPPK/3R4 b - - 0 1", "g4f3", -29),
-        ("rnb1k2r/p3p1pp/1p3p1b/7n/1N2N3/3P1PB1/PPP1P1PP/R2QKB1R w KQkq - 0 1", "e4d6", -143),
+        ("2r1k2r/pb4pp/5p1b/2KB3n/4N3/2NP1PB1/PPP1P1PP/R2Q3R w k - 0 1", "d5c6", -202),
+        ("2r1k3/pbr3pp/5p1b/2KB3n/1N2N3/3P1PB1/PPP1P1PP/R2Q3R w - - 0 1", "d5c6", -177),
+        ("2r1r1k1/pp1bppbp/3p1np1/q3P3/2P2P2/1P2B3/P1N1B1PP/2RQ1RK1 b - - 0 1", "d6e5", 53),
+        ("2r2r1k/6bp/p7/2q2p1Q/3PpP2/1B6/P5PP/2RR3K b - - 0 1", "c5c1", 30),
         ("2r2rk1/5pp1/pp5p/q2p4/P3n3/1Q3NP1/1P2PP1P/2RR2K1 b - - 0 1", "c8c1", 0),
-        ("1k1r3q/1ppn3p/p4b2/4p3/8/P2N2P1/1PP1R1BP/2K1Q3 w - - 0 1", "d3e5", -143),
-        ("r2n3r/2P1P3/4N3/1k6/8/8/8/4K3 w - - 0 1", "e6d8", 191),
-        ("4q3/1p1pr1k1/1B2rp2/6p1/p3PP2/P3R1P1/1P2R1K1/4Q3 b - - 0 1", "e6e4", -259),
+        ("2r4k/2r4p/p7/2b2p1b/4pP2/1BR5/P1R3PP/2Q4K w - - 0 1", "c3c5", 214),
+        ("2r4r/1P4pk/p2p1b1p/7n/BB3p2/2R2p2/P1P2P2/4RK2 w - - 0 1", "c3c8", 334),
+        ("3n3r/2P5/8/1k6/8/8/3Q4/4K3 w - - 0 1", "c7d8q", 447),
         ("3N4/2K5/2n5/1k6/8/8/8/8 b - - 0 1", "c6d8", 0),
-        ("r2qk1nr/pp2ppbp/2b3p1/2p1p3/8/2N2N2/PPPP1PPP/R1BQR1K1 w kq - 0 1", "f3e5", 48),
-        ("r1bqkb1r/2pp1ppp/p1n5/1p2p3/3Pn3/1B3N2/PPP2PPP/RNBQ1RK1 b kq - 0 1", "c6d4", 0),
+        ("3q2nk/pb1r1p2/np6/3P2Pp/2p1P3/2R1B2B/PQ3P1P/3R2K1 w - h6 0 1", "g5h6", 56),
         ("3q2nk/pb1r1p2/np6/3P2Pp/2p1P3/2R4B/PQ3P1P/3R2K1 w - h6 0 1", "g5h6", 0),
-        ("7R/5P2/8/8/6r1/3K4/5p2/4k3 w - - 0 1", "f7f8q", 566),
-        ("1k1r4/1ppn3p/p4b2/4n3/8/P2N2P1/1PP1R1BP/2K1Q3 w - - 0 1", "d3e5", 104),
-        ("r4rk1/1q1nppbp/b2p1np1/2pP4/8/2N2NPP/PP2PPB1/R1BQR1K1 b - - 0 1", "f6d5", -143),
-        ("5k2/p2P2pp/8/1pb5/1Nn1P1n1/6Q1/PPP4P/R3K1NR w KQ - 0 1", "d7d8q", 566),
-        ("r1b1k2r/p4npp/1pp2p1b/7n/1N2N3/3P1PB1/PPP1P1PP/R2QKB1R w KQkq - 0 1", "e4d6", 0),
-        ("r1bqk1nr/pppp1ppp/2n5/1B2p3/1b2P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1", "e1g1", 0),
+        ("3r3k/3r4/2n1n3/8/3p4/2PR4/1B1Q4/3R3K w - - 0 1", "d3d4", -132),
+        ("4kbnr/p1P1pppp/b7/4q3/7n/8/PP1PPPPP/RNBQKBNR w KQk - 0 1", "c7c8q", -53),
+        ("4kbnr/p1P1pppp/b7/4q3/7n/8/PPQPPPPP/RNB1KBNR w KQk - 0 1", "c7c8q", 149),
+        ("4kbnr/p1P4p/b1q5/5pP1/4n2Q/8/PP1PPP1P/RNB1KBNR w KQk f6 0 1", "g5f6", 0),
+        ("4kbnr/p1P4p/b1q5/5pP1/4n3/5Q2/PP1PPP1P/RNB1KBNR w KQk f6 0 1", "g5f6", 0),
+        ("4q3/1p1pr1k1/1B2rp2/6p1/p3PP2/P3R1P1/1P2R1K1/4Q3 b - - 0 1", "e6e4", -275),
+        ("4q3/1p1pr1kb/1B2rp2/6p1/p3PP2/P3R1P1/1P2R1K1/4Q3 b - - 0 1", "h7e4", 59),
+        ("4r1k1/5pp1/nbp4p/1p2p2q/1P2P1b1/1BP2N1P/1B2QPPK/3R4 b - - 0 1", "g4f3", -22),
+        ("4R3/2r3p1/5bk1/1p1r1p1p/p2PR1P1/P1BK1P2/1P6/8 b - - 0 1", "h5g4", 0),
         ("4R3/2r3p1/5bk1/1p1r3p/p2PR1P1/P1BK1P2/1P6/8 b - - 0 1", "h5g4", 0),
-        ("7r/5qpk/2Qp1b1p/1N1r3n/BB3p2/5p2/P1P2P2/4RK1R w - - 0 1", "e1e8", -307),
-        ("2r1k2r/pb4pp/5p1b/2KB3n/4N3/2NP1PB1/PPP1P1PP/R2Q3R w k - 0 1", "d5c6", -220),
-        ("7R/5P2/8/8/6r1/3K4/5p2/4k3 w - - 0 1", "f7f8b", 172),
-        ("1r3r2/5p2/4p2p/2k1n1P1/2PN1nP1/1P3P2/8/2KR1B1R b - - 0 1", "b8b3", -259),
-        ("r4rk1/3nppbp/bq1p1np1/2pP4/8/2N2NPP/PP2PPB1/R1BQR1K1 b - - 0 1", "b6b2", -566),
-        ("1n2kb1r/p1P4p/2qb4/5pP1/4n2Q/8/PP1PPP1P/RNB1KBNR w KQk - 0 1", "c7b8q", 143),
-        ("5rk1/1pp2q1p/p1pb4/8/3P1NP1/2P5/1P1BQ1P1/5RK1 b - - 0 1", "d6f4", -29),
+        ("5k2/p2P2pp/1b6/1p6/1Nn1P1n1/8/PPP4P/R2QK1NR w KQ - 0 1", "d7d8q", 154),
+        ("5k2/p2P2pp/8/1pb5/1Nn1P1n1/6Q1/PPP4P/R3K1NR w KQ - 0 1", "d7d8q", 578),
+        ("5rk1/1pp2q1p/p1pb4/8/3P1NP1/2P5/1P1BQ1P1/5RK1 b - - 0 1", "d6f4", -25),
+        ("5rk1/5pp1/2r4p/5b2/2R5/6Q1/R1P1qPP1/5NK1 b - - 0 1", "f5c2", -137),
+        ("6k1/1pp4p/p1pb4/6q1/3P1pRr/2P4P/PP1Br1P1/5RKN w - - 0 1", "f1f4", -59),
+        ("6r1/4kq2/b2p1p2/p1pPb3/p1P2B1Q/2P4P/2B1R1P1/6K1 w - - 0 1", "f4e5", 0),
+        ("6RR/4bP2/8/8/5r2/3K4/5p2/4k3 w - - 0 1", "f7f8n", 136),
+        ("6RR/4bP2/8/8/5r2/3K4/5p2/4k3 w - - 0 1", "f7f8q", 159),
+        ("6rr/6pk/p1Qp1b1p/2n5/1B3p2/5p2/P1P2P2/4RK1R w - - 0 1", "e1e8", -334),
+        ("7R/4bP2/8/8/1q6/3K4/5p2/4k3 w - - 0 1", "f7f8r", -51),
+        ("7R/5P2/8/8/6r1/3K4/5p2/4k3 w - - 0 1", "f7f8b", 159),
+        ("7R/5P2/8/8/6r1/3K4/5p2/4k3 w - - 0 1", "f7f8q", 560),
+        ("7r/5qpk/2Qp1b1p/1N1r3n/BB3p2/5p2/P1P2P2/4RK1R w - - 0 1", "e1e8", -323),
+        ("7r/5qpk/p1Qp1b1p/3r3n/BB3p2/5p2/P1P2P2/4RK1R w - - 0 1", "e1e8", 0),
+        ("8/4kp2/2npp3/1Nn5/1p2P1P1/7q/1PP1B3/4KR1r b - - 0 1", "h1f1", 0),
+        ("8/4kp2/2npp3/1Nn5/1p2PQP1/7q/1PP1B3/4KR1r b - - 0 1", "h1f1", 0),
+        ("8/8/1k6/8/8/2N1N3/4p1K1/3n4 w - - 0 1", "c3d1", 50),
+        ("8/8/8/1k6/6b1/4N3/2p3K1/3n4 w - - 0 1", "e3d1", 0),
+        ("8/pp6/2pkp3/4bp2/2R3b1/2P5/PP4B1/1K6 w - - 0 1", "g2c6", -159),
+        ("r1b1k2r/p4npp/1pp2p1b/7n/1N2N3/3P1PB1/PPP1P1PP/R2QKB1R w KQkq - 0 1", "e4d6", 0),
+        ("r1bq1r2/pp1ppkbp/4N1p1/n3P1B1/8/2N5/PPP2PPP/R2QK2R w KQ - 0 1", "e6g7", 25),
+        ("r1bq1r2/pp1ppkbp/4N1pB/n3P3/8/2N5/PPP2PPP/R2QK2R w KQ - 0 1", "e6g7", 202),
+        ("r1bqk1nr/pppp1ppp/2n5/1B2p3/1b2P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1", "e1g1", 0),
+        ("r1bqkb1r/2pp1ppp/p1n5/1p2p3/3Pn3/1B3N2/PPP2PPP/RNBQ1RK1 b kq - 0 1", "c6d4", 0),
+        ("r2n3r/2P1P3/4N3/1k6/8/8/8/4K3 w - - 0 1", "e6d8", 187),
+        ("r2q1rk1/1b2bppp/p2p1n2/1ppNp3/3nP3/P2P1N1P/BPP2PP1/R1BQR1K1 w - - 0 1", "d5e7", 25),
+        ("r2q1rk1/2p1bppp/p2p1n2/1p2P3/4P1b1/1nP1BN2/PP3PPP/RN1QR1K1 b - - 0 1", "g4f3", -25),
+        ("r2qk1nr/pp2ppbp/2b3p1/2p1p3/8/2N2N2/PPPP1PPP/R1BQR1K1 w kq - 0 1", "f3e5", 49),
+        ("r2qkbn1/ppp1pp1p/3p1rp1/3Pn3/4P1b1/2N2N2/PPP2PPP/R1BQKB1R b KQq - 0 1", "g4f3", 24),
+        ("r4k2/p2P2pp/8/1pb5/1Nn1P1n1/6Q1/PPP4P/R3K1NR w KQ - 0 1", "d7d8q", -56),
+        ("r4rk1/1q1nppbp/b2p1np1/2pP4/8/2N2NPP/PP2PPB1/R1BQR1K1 b - - 0 1", "f6d5", -118),
+        ("r4rk1/3nppbp/bq1p1np1/2pP4/8/2N2NPP/PP2PPB1/R1BQR1K1 b - - 0 1", "b6b2", -583),
+        ("rn2k2r/1bq2ppp/p2bpn2/1p1p4/3N4/1BN1P3/PPP2PPP/R1BQR1K1 b kq - 0 1", "d6h2", 49),
+        ("rnb1k2r/p3p1pp/1p3p1b/7n/1N2N3/3P1PB1/PPP1P1PP/R2QKB1R w KQkq - 0 1", "e4d6", -118),
+        ("rnb2b1r/ppp2kpp/5n2/4P3/q2P3B/5R2/PPP2PPP/RN1QKB2 w Q - 0 1", "h4f6", 28),
+        ("rnbq1rk1/pppp1ppp/4pn2/8/1bPP4/P1N5/1PQ1PPPP/R1B1KBNR b KQ - 0 1", "b4c3", -25),
+        ("rnbqk2r/pp3ppp/2p1pn2/3p4/3P4/N1P1BN2/PPB1PPPb/R2Q1RK1 w kq - 0 1", "g1h2", 192),
+        ("rnbqrbn1/pp3ppp/3p4/2p2k2/4p3/3B1K2/PPP2PPP/RNB1Q1NR w - - 0 1", "d3e4", 49),
+        ("rnq1k2r/1b3ppp/p2bpn2/1p1p4/3N4/1BN1P3/PPP2PPP/R1BQR1K1 b kq - 0 1", "d6h2", -143),
     ];
 
     #[proptest]

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -2,7 +2,7 @@ use crate::chess::{Color, Move, ParsePositionError, Perspective, Piece, Position
 use crate::nnue::{Accumulator, Feature, Nnue, Value};
 use crate::util::{Assume, Integer};
 use derive_more::with_trait::{Debug, Deref, Display};
-use std::str::FromStr;
+use std::{ops::Range, str::FromStr};
 
 #[cfg(test)]
 use proptest::prelude::*;
@@ -143,7 +143,73 @@ impl Evaluator {
         value.saturate()
     }
 
-    /// The [`Position`]'s evaluation.
+    /// Whether this move wins the exchange by at least `margin`.
+    pub fn winning(&self, m: Move, margin: Value) -> bool {
+        margin == Value::lower() || self.see(m, margin - 1..margin) == margin
+    }
+
+    /// Computes the static exchange evaluation.
+    pub fn see(&self, m: Move, bounds: Range<Value>) -> Value {
+        let phase = (self.occupied().len() - 1) / 4;
+        let pt = Nnue::pt(phase).map(|v| v / 128);
+
+        let mut score = Value::new(0);
+        let (mut alpha, mut beta) = (bounds.start, bounds.end);
+
+        if let Some(victim) = self[m.whither()] {
+            score += pt[victim.role().cast::<usize>()];
+        } else if m.is_capture() {
+            score += pt[Role::Pawn.cast::<usize>()];
+        }
+
+        if let Some(promotion) = m.promotion() {
+            score += pt[promotion.cast::<usize>()] - pt[Role::Pawn.cast::<usize>()];
+        }
+
+        beta = beta.min(score);
+
+        if alpha >= beta {
+            return alpha;
+        }
+
+        score -= match m.promotion() {
+            None => pt[self[m.whence()].assume().role().cast::<usize>()],
+            Some(promotion) => pt[promotion.cast::<usize>()],
+        };
+
+        alpha = alpha.max(score);
+
+        if alpha >= beta {
+            return beta;
+        }
+
+        let mut exchanges = self.exchanges(m);
+
+        loop {
+            let Some((_, capture, _)) = exchanges.next() else {
+                break beta;
+            };
+
+            score = -(score + pt[capture.cast::<usize>()]);
+            beta = beta.min(-score);
+
+            if alpha >= beta {
+                break alpha;
+            }
+
+            let Some((_, capture, _)) = exchanges.next() else {
+                break alpha;
+            };
+
+            score = -(score + pt[capture.cast::<usize>()]);
+            alpha = alpha.max(score);
+
+            if alpha >= beta {
+                break beta;
+            }
+        }
+    }
+
     pub fn evaluate(&self) -> Value {
         let phase = (self.occupied().len() - 1) / 4;
         let value = self.acc.evaluate(self.turn(), phase) / 128;
@@ -162,7 +228,7 @@ impl FromStr for Evaluator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::sample::Selector;
+    use proptest::sample::{Selector, select};
     use std::fmt::Debug;
     use test_strategy::proptest;
 
@@ -188,5 +254,91 @@ mod tests {
     #[proptest]
     fn parsing_printed_evaluator_is_an_identity(e: Evaluator) {
         assert_eq!(e.to_string().parse(), Ok(e));
+    }
+
+    #[rustfmt::skip]
+    const SEE_SUITE: &[(&str, &str, i16)] = &[
+        ("r1bq1r2/pp1ppkbp/4N1p1/n3P1B1/8/2N5/PPP2PPP/R2QK2R w KQ - 0 1", "e6g7", 29),
+        ("r4k2/p2P2pp/8/1pb5/1Nn1P1n1/6Q1/PPP4P/R3K1NR w KQ - 0 1", "d7d8q", -48),
+        ("rnbqrbn1/pp3ppp/3p4/2p2k2/4p3/3B1K2/PPP2PPP/RNB1Q1NR w - - 0 1", "d3e4", 48),
+        ("8/pp6/2pkp3/4bp2/2R3b1/2P5/PP4B1/1K6 w - - 0 1", "g2c6", -172),
+        ("6rr/6pk/p1Qp1b1p/2n5/1B3p2/5p2/P1P2P2/4RK1R w - - 0 1", "e1e8", -307),
+        ("2r1r1k1/pp1bppbp/3p1np1/q3P3/2P2P2/1P2B3/P1N1B1PP/2RQ1RK1 b - - 0 1", "d6e5", 48),
+        ("8/8/8/1k6/6b1/4N3/2p3K1/3n4 w - - 0 1", "e3d1", 0),
+        ("7r/5qpk/p1Qp1b1p/3r3n/BB3p2/5p2/P1P2P2/4RK1R w - - 0 1", "e1e8", 0),
+        ("6k1/1pp4p/p1pb4/6q1/3P1pRr/2P4P/PP1Br1P1/5RKN w - - 0 1", "f1f4", -39),
+        ("6RR/4bP2/8/8/5r2/3K4/5p2/4k3 w - - 0 1", "f7f8n", 143),
+        ("5k2/p2P2pp/1b6/1p6/1Nn1P1n1/8/PPP4P/R2QK1NR w KQ - 0 1", "d7d8q", 172),
+        ("4kbnr/p1P4p/b1q5/5pP1/4n2Q/8/PP1PPP1P/RNB1KBNR w KQk f6 0 1", "g5f6", 0),
+        ("4kbnr/p1P1pppp/b7/4q3/7n/8/PP1PPPPP/RNBQKBNR w KQk - 0 1", "c7c8q", -48),
+        ("r1bq1r2/pp1ppkbp/4N1pB/n3P3/8/2N5/PPP2PPP/R2QK2R w KQ - 0 1", "e6g7", 220),
+        ("r2q1rk1/1b2bppp/p2p1n2/1ppNp3/3nP3/P2P1N1P/BPP2PP1/R1BQR1K1 w - - 0 1", "d5e7", 29),
+        ("4kbnr/p1P1pppp/b7/4q3/7n/8/PPQPPPPP/RNB1KBNR w KQk - 0 1", "c7c8q", 172),
+        ("2r1k3/pbr3pp/5p1b/2KB3n/1N2N3/3P1PB1/PPP1P1PP/R2Q3R w - - 0 1", "d5c6", -191),
+        ("rn2k2r/1bq2ppp/p2bpn2/1p1p4/3N4/1BN1P3/PPP2PPP/R1BQR1K1 b kq - 0 1", "d6h2", 48),
+        ("3r3k/3r4/2n1n3/8/3p4/2PR4/1B1Q4/3R3K w - - 0 1", "d3d4", -116),
+        ("5rk1/5pp1/2r4p/5b2/2R5/6Q1/R1P1qPP1/5NK1 b - - 0 1", "f5c2", -172),
+        ("3n3r/2P5/8/1k6/8/8/3Q4/4K3 w - - 0 1", "c7d8q", 450),
+        ("1r3r2/5p2/4p2p/4n1P1/kPPN1nP1/5P2/8/2KR1B1R b - - 0 1", "b8b4", 48),
+        ("2r4k/2r4p/p7/2b2p1b/4pP2/1BR5/P1R3PP/2Q4K w - - 0 1", "c3c5", 220),
+        ("8/4kp2/2npp3/1Nn5/1p2P1P1/7q/1PP1B3/4KR1r b - - 0 1", "h1f1", 0),
+        ("rnbq1rk1/pppp1ppp/4pn2/8/1bPP4/P1N5/1PQ1PPPP/R1B1KBNR b KQ - 0 1", "b4c3", -29),
+        ("rnb2b1r/ppp2kpp/5n2/4P3/q2P3B/5R2/PPP2PPP/RN1QKB2 w Q - 0 1", "h4f6", 19),
+        ("8/4kp2/2npp3/1Nn5/1p2PQP1/7q/1PP1B3/4KR1r b - - 0 1", "h1f1", 0),
+        ("2r2r1k/6bp/p7/2q2p1Q/3PpP2/1B6/P5PP/2RR3K b - - 0 1", "c5c1", 0),
+        ("1r5k/p4pp1/2p1p2p/qpQP3P/2P2P2/1P1R4/P4rP1/1K1R4 b - - 0 1", "a5a2", 48),
+        ("1r3r1k/p4pp1/2p1p2p/qpQP3P/2P5/3R4/PP3PP1/1K1R4 b - - 0 1", "a5a2", -566),
+        ("rnbqk2r/pp3ppp/2p1pn2/3p4/3P4/N1P1BN2/PPB1PPPb/R2Q1RK1 w kq - 0 1", "g1h2", 220),
+        ("7R/4bP2/8/8/1q6/3K4/5p2/4k3 w - - 0 1", "f7f8r", -48),
+        ("4R3/2r3p1/5bk1/1p1r1p1p/p2PR1P1/P1BK1P2/1P6/8 b - - 0 1", "h5g4", 0),
+        ("8/8/1k6/8/8/2N1N3/4p1K1/3n4 w - - 0 1", "c3d1", 48),
+        ("r2q1rk1/2p1bppp/p2p1n2/1p2P3/4P1b1/1nP1BN2/PP3PPP/RN1QR1K1 b - - 0 1", "g4f3", -29),
+        ("4kbnr/p1P4p/b1q5/5pP1/4n3/5Q2/PP1PPP1P/RNB1KBNR w KQk f6 0 1", "g5f6", 0),
+        ("r2qkbn1/ppp1pp1p/3p1rp1/3Pn3/4P1b1/2N2N2/PPP2PPP/R1BQKB1R b KQq - 0 1", "g4f3", 19),
+        ("2r4r/1P4pk/p2p1b1p/7n/BB3p2/2R2p2/P1P2P2/4RK2 w - - 0 1", "c3c8", 307),
+        ("rnq1k2r/1b3ppp/p2bpn2/1p1p4/3N4/1BN1P3/PPP2PPP/R1BQR1K1 b kq - 0 1", "d6h2", -172),
+        ("4q3/1p1pr1kb/1B2rp2/6p1/p3PP2/P3R1P1/1P2R1K1/4Q3 b - - 0 1", "h7e4", 48),
+        ("6r1/4kq2/b2p1p2/p1pPb3/p1P2B1Q/2P4P/2B1R1P1/6K1 w - - 0 1", "f4e5", 0),
+        ("6RR/4bP2/8/8/5r2/3K4/5p2/4k3 w - - 0 1", "f7f8q", 172),
+        ("3q2nk/pb1r1p2/np6/3P2Pp/2p1P3/2R1B2B/PQ3P1P/3R2K1 w - h6 0 1", "g5h6", 48),
+        ("2r1k2r/pb4pp/5p1b/2KB3n/1N2N3/3P1PB1/PPP1P1PP/R2Q3R w k - 0 1", "d5c6", 0),
+        ("4r1k1/5pp1/nbp4p/1p2p2q/1P2P1b1/1BP2N1P/1B2QPPK/3R4 b - - 0 1", "g4f3", -29),
+        ("rnb1k2r/p3p1pp/1p3p1b/7n/1N2N3/3P1PB1/PPP1P1PP/R2QKB1R w KQkq - 0 1", "e4d6", -143),
+        ("2r2rk1/5pp1/pp5p/q2p4/P3n3/1Q3NP1/1P2PP1P/2RR2K1 b - - 0 1", "c8c1", 0),
+        ("1k1r3q/1ppn3p/p4b2/4p3/8/P2N2P1/1PP1R1BP/2K1Q3 w - - 0 1", "d3e5", -143),
+        ("r2n3r/2P1P3/4N3/1k6/8/8/8/4K3 w - - 0 1", "e6d8", 191),
+        ("4q3/1p1pr1k1/1B2rp2/6p1/p3PP2/P3R1P1/1P2R1K1/4Q3 b - - 0 1", "e6e4", -259),
+        ("3N4/2K5/2n5/1k6/8/8/8/8 b - - 0 1", "c6d8", 0),
+        ("r2qk1nr/pp2ppbp/2b3p1/2p1p3/8/2N2N2/PPPP1PPP/R1BQR1K1 w kq - 0 1", "f3e5", 48),
+        ("r1bqkb1r/2pp1ppp/p1n5/1p2p3/3Pn3/1B3N2/PPP2PPP/RNBQ1RK1 b kq - 0 1", "c6d4", 0),
+        ("3q2nk/pb1r1p2/np6/3P2Pp/2p1P3/2R4B/PQ3P1P/3R2K1 w - h6 0 1", "g5h6", 0),
+        ("7R/5P2/8/8/6r1/3K4/5p2/4k3 w - - 0 1", "f7f8q", 566),
+        ("1k1r4/1ppn3p/p4b2/4n3/8/P2N2P1/1PP1R1BP/2K1Q3 w - - 0 1", "d3e5", 104),
+        ("r4rk1/1q1nppbp/b2p1np1/2pP4/8/2N2NPP/PP2PPB1/R1BQR1K1 b - - 0 1", "f6d5", -143),
+        ("5k2/p2P2pp/8/1pb5/1Nn1P1n1/6Q1/PPP4P/R3K1NR w KQ - 0 1", "d7d8q", 566),
+        ("r1b1k2r/p4npp/1pp2p1b/7n/1N2N3/3P1PB1/PPP1P1PP/R2QKB1R w KQkq - 0 1", "e4d6", 0),
+        ("r1bqk1nr/pppp1ppp/2n5/1B2p3/1b2P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1", "e1g1", 0),
+        ("4R3/2r3p1/5bk1/1p1r3p/p2PR1P1/P1BK1P2/1P6/8 b - - 0 1", "h5g4", 0),
+        ("7r/5qpk/2Qp1b1p/1N1r3n/BB3p2/5p2/P1P2P2/4RK1R w - - 0 1", "e1e8", -307),
+        ("2r1k2r/pb4pp/5p1b/2KB3n/4N3/2NP1PB1/PPP1P1PP/R2Q3R w k - 0 1", "d5c6", -220),
+        ("7R/5P2/8/8/6r1/3K4/5p2/4k3 w - - 0 1", "f7f8b", 172),
+        ("1r3r2/5p2/4p2p/2k1n1P1/2PN1nP1/1P3P2/8/2KR1B1R b - - 0 1", "b8b3", -259),
+        ("r4rk1/3nppbp/bq1p1np1/2pP4/8/2N2NPP/PP2PPB1/R1BQR1K1 b - - 0 1", "b6b2", -566),
+        ("1n2kb1r/p1P4p/2qb4/5pP1/4n2Q/8/PP1PPP1P/RNB1KBNR w KQk - 0 1", "c7b8q", 143),
+        ("5rk1/1pp2q1p/p1pb4/8/3P1NP1/2P5/1P1BQ1P1/5RK1 b - - 0 1", "d6f4", -29),
+    ];
+
+    #[proptest]
+    fn see_estimates_quiescent_move_gain(
+        #[strategy(select(SEE_SUITE))] entry: (&'static str, &'static str, i16),
+    ) {
+        let (fen, uci, value) = entry;
+        let e: Evaluator = fen.parse()?;
+        let m = e.moves().flatten().find(|m| m.to_string() == uci).unwrap();
+        assert_eq!(e.see(m, Value::lower()..Value::upper()), value);
+
+        assert!(e.winning(m, Value::new(value)));
+        assert!(e.winning(m, Value::new(value - 1)));
+        assert!(!e.winning(m, Value::new(value + 1)));
     }
 }

--- a/lib/search/depth.rs
+++ b/lib/search/depth.rs
@@ -14,7 +14,7 @@ unsafe impl Integer for DepthRepr {
     const MAX: Self::Repr = 63;
 
     #[cfg(test)]
-    const MAX: Self::Repr = 15;
+    const MAX: Self::Repr = 7;
 }
 
 /// The search depth.

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -354,6 +354,11 @@ impl<'a> Stack<'a> {
                 break;
             }
 
+            let benchmark = Value::new(75) * (draft - lmr);
+            if pos.see(m, -benchmark) < -benchmark {
+                continue;
+            }
+
             let mut next = pos.clone();
             next.play(m);
             self.tt.prefetch(next.zobrist());


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 20000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 12.69 +/- 5.37, nElo: 20.55 +/- 8.69
LOS: 100.00 %, DrawRatio: 44.10 %, PairsRatio: 1.25
Games: 6136, Wins: 1676, Losses: 1452, Draws: 3008, Points: 3180.0 (51.83 %)
Ptnml(0-2): [91, 670, 1353, 832, 122], WL/DD Ratio: 0.80
LLR: 2.89 (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```


### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.4
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:25s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     68     64     69     75     76     56     63     62     55     67     48     57     65     59     53    937
   Score   7822   7452   7979   8528   8259   7669   7559   7476   6540   7528   6285   6841   7181   7271   6809 111199
Score(%)   92.0   93.2   92.8   95.8   97.2   95.9   92.2   93.5   92.1   95.3   89.8   92.4   95.7   92.0   93.3   93.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 97.2%, "Bishop vs Knight"
2. STS 06, 95.9%, "Re-Capturing"
3. STS 04, 95.8%, "Square Vacancy"
4. STS 13, 95.7%, "Pawn Play in the Center"
5. STS 10, 95.3%, "Simplification"

:: Top 5 STS with low result ::
1. STS 11, 89.8%, "Activity of the King"
2. STS 01, 92.0%, "Undermining"
3. STS 14, 92.0%, "Queens and Rooks to the 7th rank"
4. STS 09, 92.1%, "Advancement of a/b/c Pawns"
5. STS 07, 92.2%, "Offer of Simplification"
```
