### PR TITLE
Restrict futility pruning to nodes failing low

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -329,8 +329,8 @@ impl<'a> Stack<'a> {
 
             let lmr = self.lmr(draft, idx) - (is_pv as i8) - improving;
             let margin = alpha - self.value[ply.cast::<usize>()] - self.futility(draft - lmr);
-            if !pos.winning(m, margin.saturate()) {
-                continue;
+            if margin > 0 && !pos.winning(m, margin.saturate()) {
+                break;
             }
 
             let mut next = pos.clone();
@@ -393,8 +393,8 @@ impl<'a> Stack<'a> {
 
             let lmr = self.lmr(depth, idx) - 1;
             let margin = alpha - self.value[0] - self.futility(depth - lmr);
-            if !self.root.winning(m, margin.saturate()) {
-                continue;
+            if margin > 0 && !self.root.winning(m, margin.saturate()) {
+                break;
             }
 
             let mut next = self.root.clone();


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 20000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 18.73 +/- 6.67, nElo: 29.62 +/- 10.54
LOS: 100.00 %, DrawRatio: 40.02 %, PairsRatio: 1.33
Games: 4178, Wins: 1195, Losses: 970, Draws: 2013, Points: 2201.5 (52.69 %)
Ptnml(0-2): [50, 487, 836, 620, 96], WL/DD Ratio: 0.85
Warning; Engine base is not responsive.
LLR: 2.90 (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```


### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.4
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:27s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     70     64     66     77     74     59     63     60     51     67     53     57     64     62     49    936
   Score   7915   7334   7710   8619   8274   7705   7492   7273   6354   7492   6549   6903   6998   7401   6710 110729
Score(%)   93.1   91.7   89.7   96.8   97.3   96.3   91.4   90.9   89.5   94.8   93.6   93.3   93.3   93.7   91.9   93.2

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 97.3%, "Bishop vs Knight"
2. STS 04, 96.8%, "Square Vacancy"
3. STS 06, 96.3%, "Re-Capturing"
4. STS 10, 94.8%, "Simplification"
5. STS 14, 93.7%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 09, 89.5%, "Advancement of a/b/c Pawns"
2. STS 03, 89.7%, "Knight Outposts"
3. STS 08, 90.9%, "Advancement of f/g/h Pawns"
4. STS 07, 91.4%, "Offer of Simplification"
5. STS 02, 91.7%, "Open Files and Diagonals"
```
