### PR TITLE
Implement static see pruning

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -151,7 +151,12 @@ impl<'a> Stack<'a> {
 
     /// Computes the futility margin.
     fn futility(&self, draft: Depth) -> Value {
-        (draft.cast::<i16>() * 80 + 60).saturate()
+        Value::new(80) * draft + 60
+    }
+
+    /// Computes the static SEE pruning margin.
+    fn ssp(&self, draft: Depth) -> Value {
+        Value::new(75) * draft
     }
 
     /// The zero-window alpha-beta search.
@@ -331,6 +336,8 @@ impl<'a> Stack<'a> {
             let margin = alpha - self.value[ply.cast::<usize>()] - self.futility(draft - lmr);
             if margin > 0 && !pos.winning(m, margin.saturate()) {
                 break;
+            } else if margin <= 0 && !pos.winning(m, -self.ssp(draft - lmr)) {
+                continue;
             }
 
             let mut next = pos.clone();


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 20000 -openings file=engines/openings/UHO_2024_+085_+094/UHO_2024_8mvs_+085_+094.epd order=random plies=8 -concurrency 12 -use-affinity -recover -log file=stderr.log level=err realtime=true -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_2024_8mvs_+085_+094.epd):
Elo: 10.20 +/- 4.78, nElo: 16.38 +/- 7.68
LOS: 100.00 %, DrawRatio: 43.28 %, PairsRatio: 1.20
Games: 7870, Wins: 2125, Losses: 1894, Draws: 3851, Points: 4050.5 (51.47 %)
Ptnml(0-2): [126, 887, 1703, 1068, 151], WL/DD Ratio: 0.80
LLR: 2.90 (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```


### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.4
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:26s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     68     62     70     79     74     63     63     64     56     65     55     59     70     66     48    962
   Score   7961   7392   7937   8677   8328   7799   7486   7532   6495   7435   6571   6944   7273   7524   6558 111912
Score(%)   93.7   92.4   92.3   97.5   98.0   97.5   91.3   94.2   91.5   94.1   93.9   93.8   97.0   95.2   89.8   94.2

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 98.0%, "Bishop vs Knight"
2. STS 04, 97.5%, "Square Vacancy"
3. STS 06, 97.5%, "Re-Capturing"
4. STS 13, 97.0%, "Pawn Play in the Center"
5. STS 14, 95.2%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 15, 89.8%, "Avoid Pointless Exchange"
2. STS 07, 91.3%, "Offer of Simplification"
3. STS 09, 91.5%, "Advancement of a/b/c Pawns"
4. STS 03, 92.3%, "Knight Outposts"
5. STS 02, 92.4%, "Open Files and Diagonals"

```
