### PR TITLE
Replace Index<Sq> for Position by fns color_on, role_on, and piece_on 

### DIFF
--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -110,8 +110,8 @@ impl Evaluator {
         if !m.is_quiet() {
             let pieces = Nnue::pieces((self.occupied().len() - 1) / 4);
 
-            if let Some(victim) = self[m.whither()] {
-                gain += pieces[victim.role().cast::<usize>()];
+            if let Some(victim) = self.role_on(m.whither()) {
+                gain += pieces[victim.cast::<usize>()];
             } else if m.is_capture() {
                 gain += pieces[Role::Pawn.cast::<usize>()];
             }
@@ -146,7 +146,7 @@ impl Evaluator {
         let pieces = Nnue::pieces((self.occupied().len() - 1) / 4);
 
         score -= match m.promotion() {
-            None => pieces[self[m.whence()].assume().role().cast::<usize>()] / scale,
+            None => pieces[self.role_on(m.whence()).assume().cast::<usize>()] / scale,
             Some(promotion) => pieces[promotion.cast::<usize>()] / scale,
         };
 

--- a/lib/search/continuation.rs
+++ b/lib/search/continuation.rs
@@ -17,8 +17,8 @@ impl Default for Reply {
 impl Reply {
     #[inline(always)]
     fn graviton(&self, pos: &Position, m: Move) -> &Graviton {
-        let piece = pos[m.whence()].assume().role() as usize;
-        &self.0[piece][m.whither() as usize]
+        let role = pos.role_on(m.whence()).assume() as usize;
+        &self.0[role][m.whither() as usize]
     }
 }
 
@@ -50,8 +50,8 @@ impl Default for Continuation {
 impl Continuation {
     #[inline(always)]
     pub fn reply(&self, pos: &Position, m: Move) -> &Reply {
-        let piece = pos[m.whence()].assume() as usize;
-        let victim = pos[m.whither()].map_or(Role::King, |p| p.role()) as usize;
+        let piece = pos.piece_on(m.whence()).assume() as usize;
+        let victim = pos.role_on(m.whither()).unwrap_or(Role::King) as usize;
         &self.0[piece][m.whither() as usize][victim]
     }
 }


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 8.37 +/- 4.20, nElo: 14.14 +/- 7.08
LOS: 100.00 %, DrawRatio: 46.08 %, PairsRatio: 1.16
Games: 9254, Wins: 2468, Losses: 2245, Draws: 4541, Points: 4738.5 (51.20 %)
Ptnml(0-2): [109, 1045, 2132, 1196, 145], WL/DD Ratio: 0.85
LLR: 2.90 (100.4%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```


### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: Cinder 0.1.4
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:28s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     70     65     68     77     77     63     63     57     53     70     54     63     63     67     50    960
   Score   7902   7468   7932   8604   8310   7691   7486   7186   6514   7720   6561   7021   7051   7575   6735 111756
Score(%)   93.0   93.3   92.2   96.7   97.8   96.1   91.3   89.8   91.7   97.7   93.7   94.9   94.0   95.9   92.3   94.1

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 97.8%, "Bishop vs Knight"
2. STS 10, 97.7%, "Simplification"
3. STS 04, 96.7%, "Square Vacancy"
4. STS 06, 96.1%, "Re-Capturing"
5. STS 14, 95.9%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 08, 89.8%, "Advancement of f/g/h Pawns"
2. STS 07, 91.3%, "Offer of Simplification"
3. STS 09, 91.7%, "Advancement of a/b/c Pawns"
4. STS 03, 92.2%, "Knight Outposts"
5. STS 15, 92.3%, "Avoid Pointless Exchange"
```