### PR TITLE
A couple of micro optimizations

### DIFF
--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -209,7 +209,7 @@ mod tests {
     #[proptest]
     fn play_updates_evaluator(
         #[filter(#e.outcome().is_none())] mut e: Evaluator,
-        #[map(|sq: Selector| sq.select(#e.moves().flatten()))] m: Move,
+        #[map(|sq: Selector| sq.select(#e.moves().unpack()))] m: Move,
     ) {
         let mut pos = e.pos.clone();
         e.play(m);
@@ -308,7 +308,7 @@ mod tests {
     ) {
         let (fen, uci, value) = entry;
         let e: Evaluator = fen.parse()?;
-        let m = e.moves().flatten().find(|m| m.to_string() == uci).unwrap();
+        let m = e.moves().unpack().find(|m| m.to_string() == uci).unwrap();
         assert_eq!(e.see(m, Value::lower()..Value::upper()), value);
 
         assert!(e.winning(m, Value::new(value)));

--- a/lib/search/continuation.rs
+++ b/lib/search/continuation.rs
@@ -1,4 +1,4 @@
-use crate::chess::{Move, Position, Role};
+use crate::chess::{Move, Position};
 use crate::search::{Graviton, Stat, Statistics};
 use crate::util::Assume;
 use derive_more::with_trait::Debug;
@@ -38,7 +38,7 @@ impl Statistics for Reply {
 
 #[derive(Debug)]
 #[debug("Continuation")]
-pub struct Continuation([[[Reply; 6]; 64]; 12]);
+pub struct Continuation([[[Reply; 64]; 2]; 12]);
 
 impl Default for Continuation {
     #[inline(always)]
@@ -51,7 +51,6 @@ impl Continuation {
     #[inline(always)]
     pub fn reply(&self, pos: &Position, m: Move) -> &Reply {
         let piece = pos.piece_on(m.whence()).assume() as usize;
-        let victim = pos.role_on(m.whither()).unwrap_or(Role::King) as usize;
-        &self.0[piece][m.whither() as usize][victim]
+        &self.0[piece][m.is_quiet() as usize][m.whither() as usize]
     }
 }

--- a/lib/search/history.rs
+++ b/lib/search/history.rs
@@ -21,7 +21,7 @@ impl History {
     #[inline(always)]
     fn graviton(&self, pos: &Position, m: Move) -> &Graviton {
         let (wc, wt) = (m.whence() as usize, m.whither() as usize);
-        &self.0[pos.turn() as usize][m.is_capture() as usize][wc][wt]
+        &self.0[pos.turn() as usize][m.is_quiet() as usize][wc][wt]
     }
 }
 

--- a/lib/util/align.rs
+++ b/lib/util/align.rs
@@ -3,4 +3,4 @@ use derive_more::with_trait::{Deref, DerefMut, IntoIterator};
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, IntoIterator)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(align(64))]
-pub struct AlignTo64<T>(#[cfg_attr(test, into_iterator(owned, ref, ref_mut))] pub T);
+pub struct AlignTo64<T>(#[into_iterator(owned, ref, ref_mut)] pub T);


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 3.28 +/- 2.37, nElo: 5.55 +/- 4.02
LOS: 99.66 %, DrawRatio: 47.31 %, PairsRatio: 1.06
Games: 28740, Wins: 7554, Losses: 7283, Draws: 13903, Points: 14505.5 (50.47 %)
Ptnml(0-2): [384, 3291, 6799, 3462, 434], WL/DD Ratio: 0.90
LLR: 2.89 (100.0%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```