### PR TITLE
Decouple SEE pruning from late move reductions

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -389,18 +389,15 @@ impl<'a> Stack<'a> {
 
             if self.lmp(draft, idx) > improving {
                 break;
+            } else if !pos.winning(m, Value::new(1) - self.spt(draft)) {
+                continue;
             }
 
             let lmr = Depth::new(cut as _) + self.lmr(draft, idx) - is_pv as i8 - improving;
             if self.value[ply.cast::<usize>()] + self.futility(draft - lmr) <= alpha {
-                let threshold = self.fpt(draft - lmr);
-                if !pos.winning(m, Value::new(1) + threshold) {
+                if !pos.winning(m, Value::new(1) + self.fpt(draft - lmr)) {
                     continue;
                 }
-            }
-
-            if !pos.winning(m, Value::new(1) - self.spt(draft - lmr)) {
-                continue;
             }
 
             let mut next = pos.clone();
@@ -463,8 +460,7 @@ impl<'a> Stack<'a> {
 
             let lmr = Depth::new(0) + self.lmr(depth, idx);
             if self.value[0] + self.futility(depth - lmr) <= alpha {
-                let threshold = self.fpt(depth - lmr);
-                if !self.root.winning(m, Value::new(1) + threshold) {
+                if !self.root.winning(m, Value::new(1) + self.fpt(depth - lmr)) {
                     continue;
                 }
             }


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 2.17 +/- 1.74, nElo: 3.59 +/- 2.88
LOS: 99.27 %, DrawRatio: 44.96 %, PairsRatio: 1.04
Games: 55832, Wins: 14546, Losses: 14198, Draws: 27088, Points: 28090.0 (50.31 %)
Ptnml(0-2): [793, 6744, 12551, 6978, 850], WL/DD Ratio: 0.88
LLR: 2.90 (100.4%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```