### PR TITLE
Implement double extension

### DIFF
--- a/lib/params.rs
+++ b/lib/params.rs
@@ -134,6 +134,8 @@ params! {
     fail_low_reduction_beta: Param<10992, 5000, 17000, 1>,
     singular_extension_margin_alpha: Param<10465, 5000, 17000, 100>,
     singular_extension_margin_beta: Param<2680, 0, 4000, 100>,
+    double_extension_margin_alpha: Param<12800, 5000, 17000, 100>,
+    double_extension_margin_beta: Param<5000, 0, 8000, 100>,
     futility_margin_alpha: Param<9815, 5000, 17000, 1>,
     futility_margin_beta: Param<7821, 3000, 12000, 1>,
     futility_pruning_threshold_alpha: Param<682, 0, 4000, 1>,


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 4.82 +/- 3.03, nElo: 8.23 +/- 5.17
LOS: 99.91 %, DrawRatio: 45.89 %, PairsRatio: 1.10
Games: 17362, Wins: 4522, Losses: 4281, Draws: 8559, Points: 8801.5 (50.69 %)
Ptnml(0-2): [200, 2040, 3984, 2233, 224], WL/DD Ratio: 0.86
LLR: 2.90 (100.4%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```