### PR TITLE
Rank losing captures lower

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -341,9 +341,15 @@ impl<'a> Stack<'a> {
                     return (m, Value::upper());
                 }
 
-                let history = &self.searcher.history;
-                let counter = self.replies[ply.cast::<usize>() - 1];
-                let mut rating = pos.gain(m) + history.get(pos, m) + counter.get(pos, m);
+                let mut rating = Value::new(0);
+
+                rating += self.searcher.history.get(pos, m);
+                rating += self.replies[ply.cast::<usize>() - 1].get(pos, m);
+
+                let gain = pos.gain(m);
+                if gain > 0 && pos.winning(m, Value::new(1)) {
+                    rating += gain;
+                }
 
                 if killer.contains(m) {
                     rating += killer_bonus / value_scale;


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 5.45 +/- 3.30, nElo: 9.05 +/- 5.47
LOS: 99.94 %, DrawRatio: 44.79 %, PairsRatio: 1.11
Games: 15486, Wins: 4164, Losses: 3921, Draws: 7401, Points: 7864.5 (50.78 %)
Ptnml(0-2): [214, 1814, 3468, 2009, 238], WL/DD Ratio: 0.94
LLR: 2.90 (100.4%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```