### PR TITLE
Parametrize conversion of gain to rating for noisy moves

### DIFF
--- a/lib/params.rs
+++ b/lib/params.rs
@@ -147,6 +147,8 @@ params! {
     late_move_pruning_alpha: Param<5094, 2000, 9000, 1>,
     late_move_pruning_beta: Param<9783, 5000, 16000, 1>,
     killer_move_bonus: Param<11528, 6000, 19000, 1>,
+    noisy_gain_rating_alpha: Param<1920, 1000, 4000, 10>,
+    noisy_gain_rating_beta: Param<19200, 15000, 30000, 10>,
     aspiration_window_start: Param<6215, 3000, 10000, 10>,
     aspiration_window_alpha: Param<1538, 0, 4000, 10>,
     aspiration_window_beta: Param<1398, 0, 4000, 10>,


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 6.77 +/- 3.74, nElo: 11.29 +/- 6.24
LOS: 99.98 %, DrawRatio: 44.99 %, PairsRatio: 1.13
Games: 11908, Wins: 3192, Losses: 2960, Draws: 5756, Points: 6070.0 (50.97 %)
Ptnml(0-2): [155, 1380, 2679, 1558, 182], WL/DD Ratio: 0.90
LLR: 2.89 (100.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```