### PR TITLE
Treat the position as not improving when in check

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -103,7 +103,11 @@ impl<'a> Stack<'a> {
     }
 
     /// A measure for how much the position is improving.
-    fn improving(&mut self, ply: Ply) -> i32 {
+    fn improving(&mut self, pos: &Position, ply: Ply) -> i32 {
+        if pos.is_check() {
+            return 0;
+        }
+
         let idx = ply.cast::<usize>();
 
         let a = (idx >= 2 && self.value[idx] > self.value[idx - 2]) as i32;
@@ -418,7 +422,7 @@ impl<'a> Stack<'a> {
             }
         };
 
-        let improving = self.improving(ply);
+        let improving = self.improving(pos, ply);
         for (idx, &(m, _)) in moves.iter().rev().skip(1).enumerate() {
             let alpha = match tail.score() {
                 s if s >= beta => break,


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 5.72 +/- 3.40, nElo: 9.51 +/- 5.65
LOS: 99.95 %, DrawRatio: 45.42 %, PairsRatio: 1.10
Games: 14526, Wins: 3856, Losses: 3617, Draws: 7053, Points: 7382.5 (50.82 %)
Ptnml(0-2): [191, 1695, 3299, 1840, 238], WL/DD Ratio: 0.88
LLR: 2.89 (100.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```