### PR TITLE
Reimplement reverse futility pruning

### DIFF
--- a/lib/params.rs
+++ b/lib/params.rs
@@ -134,6 +134,8 @@ params! {
     single_extension_margin_beta: Param<3002, 1000, 5000, 100>,
     double_extension_margin_alpha: Param<12020, 6000, 19000, 100>,
     double_extension_margin_beta: Param<4963, 2000, 8000, 100>,
+    reverse_futility_margin_alpha: Param<2048, 0, 4000, 1>,
+    reverse_futility_margin_beta: Param<1000, 0, 4000, 1>,
     futility_margin_alpha: Param<6597, 3000, 10000, 1>,
     futility_margin_beta: Param<8361, 4000, 13000, 1>,
     futility_pruning_threshold_alpha: Param<1042, 0, 4000, 1>,


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 7.96 +/- 4.05, nElo: 13.68 +/- 6.96
LOS: 99.99 %, DrawRatio: 46.55 %, PairsRatio: 1.16
Games: 9560, Wins: 2521, Losses: 2302, Draws: 4737, Points: 4889.5 (51.15 %)
Ptnml(0-2): [98, 1087, 2225, 1238, 132], WL/DD Ratio: 0.84
LLR: 2.89 (100.0%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```