### PR TITLE
Reduce correction history buckets to 8192

### DIFF
--- a/lib/search/correction.rs
+++ b/lib/search/correction.rs
@@ -3,7 +3,7 @@ use crate::search::{Graviton, Stat, Statistics};
 use crate::util::Integer;
 use derive_more::with_trait::Debug;
 
-const BUCKETS: usize = 16384;
+const BUCKETS: usize = 8192;
 
 /// Historical statistics about a [`Move`].
 #[derive(Debug)]


### PR DESCRIPTION
## SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 400000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 1.62 +/- 1.31, nElo: 2.72 +/- 2.20
LOS: 99.23 %, DrawRatio: 45.64 %, PairsRatio: 1.03
Games: 95792, Wins: 25407, Losses: 24960, Draws: 45425, Points: 48119.5 (50.23 %)
Ptnml(0-2): [1300, 11534, 21861, 11821, 1380], WL/DD Ratio: 0.98
LLR: 2.90 (100.4%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```