### PR TITLE
Isolate time management per search thread 

### DIFF
--- a/lib/search/control.rs
+++ b/lib/search/control.rs
@@ -1,9 +1,11 @@
-use crate::chess::{Butterfly, Position};
-use crate::search::{Attention, Limits, Ply, Pv};
+use crate::chess::Position;
+use crate::nnue::Evaluator;
+use crate::search::{Attention, Limits, Pv};
 use crate::{params::Params, util::Integer};
+use derive_more::with_trait::Deref;
+use std::ops::Range;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
-use std::{array::from_fn, ops::Range};
 
 /// Controls the search flow.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -16,20 +18,17 @@ pub enum ControlFlow {
     Abort,
 }
 
-/// The search control.
+/// The global search control.
 #[derive(Debug)]
-pub struct Control {
-    limits: Limits,
-    nodes: AtomicU64,
-    attention: Attention,
+pub struct GlobalControl {
+    abort: AtomicBool,
+    visited: AtomicU64,
     time: Range<f64>,
     timestamp: Instant,
-    trend: AtomicU64,
-    abort: AtomicBool,
-    stop: Butterfly<AtomicBool>,
+    limits: Limits,
 }
 
-impl Control {
+impl GlobalControl {
     #[inline(always)]
     fn time_to_search(pos: &Position, limits: &Limits) -> Range<f64> {
         let (clock, inc) = match limits.clock {
@@ -51,15 +50,12 @@ impl Control {
 
     /// Sets up the controller for a new search.
     #[inline(always)]
-    pub fn new(pos: &Position, limits: Limits) -> Control {
-        Control {
-            nodes: AtomicU64::new(limits.max_nodes()),
-            attention: Attention::default(),
+    pub fn new(pos: &Position, limits: Limits) -> GlobalControl {
+        GlobalControl {
+            abort: AtomicBool::new(false),
+            visited: AtomicU64::new(limits.max_nodes()),
             time: Self::time_to_search(pos, &limits),
             timestamp: Instant::now(),
-            trend: AtomicU64::new(f64::NAN.to_bits()),
-            abort: AtomicBool::new(false),
-            stop: from_fn(|_| from_fn(|_| AtomicBool::new(false))),
             limits,
         }
     }
@@ -72,22 +68,16 @@ impl Control {
 
     /// The time elapsed so far.
     #[inline(always)]
-    pub fn time(&self) -> Duration {
+    pub fn elapsed(&self) -> Duration {
         Instant::now()
             .saturating_duration_since(self.timestamp)
             .max(Duration::from_nanos(1))
     }
 
-    /// The nodes counted so far.
+    /// The nodes visited so far.
     #[inline(always)]
-    pub fn nodes(&self) -> u64 {
-        self.limits.max_nodes() - self.nodes.load(Ordering::Relaxed)
-    }
-
-    /// The PV [`Attention`] statistics.
-    #[inline(always)]
-    pub fn attention(&self) -> &Attention {
-        &self.attention
+    pub fn visited(&self) -> u64 {
+        self.limits.max_nodes() - self.visited.load(Ordering::Relaxed)
     }
 
     /// Interrupts an ongoing search.
@@ -95,22 +85,50 @@ impl Control {
     pub fn abort(&self) {
         self.abort.store(true, Ordering::Relaxed);
     }
+}
+
+/// The local search control.
+#[derive(Debug, Deref)]
+pub struct LocalControl<'a> {
+    #[deref]
+    global: &'a GlobalControl,
+    attention: Attention,
+    nodes: u64,
+    trend: f64,
+}
+
+impl<'a> LocalControl<'a> {
+    #[inline(always)]
+    pub fn new(global: &'a GlobalControl) -> Self {
+        LocalControl {
+            global,
+            attention: Default::default(),
+            nodes: 0,
+            trend: f64::NAN,
+        }
+    }
+
+    /// The PV [`Attention`] statistics.
+    #[inline(always)]
+    pub fn attention(&mut self) -> &mut Attention {
+        &mut self.attention
+    }
 
     /// Whether the search should expand a node.
     #[inline(always)]
-    pub fn check(&self, pv: &Pv, ply: Ply) -> ControlFlow {
-        use Ordering::Relaxed;
-
-        if self.abort.load(Relaxed) {
-            return ControlFlow::Abort;
-        }
-
-        let Some(best) = pv.head() else {
+    pub fn check(&mut self, pv: &Pv, evaluator: &Evaluator) -> ControlFlow {
+        let score = pv.score().get() as f64;
+        let Some(head) = pv.head() else {
             return ControlFlow::Continue;
         };
 
-        let checked_dec = |i: u64| i.checked_sub(1);
-        let nodes = match self.nodes.fetch_update(Relaxed, Relaxed, checked_dec) {
+        if self.abort.load(Ordering::Relaxed) {
+            return ControlFlow::Abort;
+        }
+
+        use Ordering::Relaxed;
+        let dec = |i: u64| i.checked_sub(1);
+        let visited = match self.global.visited.fetch_update(Relaxed, Relaxed, dec) {
             Ok(count) => self.limits.max_nodes() - count,
             Err(_) => {
                 self.abort.store(true, Relaxed);
@@ -118,44 +136,36 @@ impl Control {
             }
         };
 
-        let inertia = Params::score_trend_inertia() as f64 / Params::BASE as f64;
-        let _ = self.trend.fetch_update(Relaxed, Relaxed, |bits| {
-            let score = pv.score().get() as f64;
-            match f64::from_bits(bits) {
-                s if s.is_nan() => Some(score.to_bits()),
-                s if ply == 0 => Some(((s * inertia + score) / (inertia + 1.)).to_bits()),
-                _ => None,
-            }
-        });
+        self.nodes += 1;
+        if self.trend.is_nan() {
+            self.trend = score;
+        } else if evaluator.ply() == 0 {
+            let inertia = Params::score_trend_inertia() as f64 / Params::BASE as f64;
+            self.trend = (self.trend * inertia + score) / (inertia + 1.);
+        }
 
-        let stop = &self.stop[best.whence() as usize][best.whither() as usize];
-        let focus_gamma = Params::pv_focus_gamma() as f64 / Params::BASE as f64;
-        let focus_delta = Params::pv_focus_delta() as f64 / Params::BASE as f64;
-        let trend_magnitude = Params::score_trend_magnitude() as f64 / Params::BASE as f64;
-        let trend_pivot = Params::score_trend_pivot() as f64 / Params::BASE as f64;
-
-        if nodes.is_multiple_of(1024) {
-            let time = self.time().as_secs_f64();
-            let focus = self.attention.nodes(best).get() as f64 / nodes.max(1024) as f64;
-            let delta = f64::from_bits(self.trend.load(Relaxed)) - pv.score().get() as f64;
-            let focus_scale = focus_delta - focus_gamma * focus;
-            let trend_scale = 1. + trend_magnitude * delta / (delta.abs() + trend_pivot);
-            let soft_time_scale = focus_scale * trend_scale;
-
+        if visited.is_multiple_of(2048) || evaluator.ply() == 0 {
+            let time = self.elapsed().as_secs_f64();
             if time >= self.time.end {
-                self.abort.store(true, Relaxed);
+                self.abort.store(true, Ordering::Relaxed);
                 return ControlFlow::Abort;
-            } else if time >= self.time.start * soft_time_scale {
-                stop.store(true, Relaxed);
-                return ControlFlow::Stop;
+            } else if evaluator.ply() == 0 {
+                let gamma = Params::pv_focus_gamma() as f64 / Params::BASE as f64;
+                let delta = Params::pv_focus_delta() as f64 / Params::BASE as f64;
+                let pivot = Params::score_trend_pivot() as f64 / Params::BASE as f64;
+                let magnitude = Params::score_trend_magnitude() as f64 / Params::BASE as f64;
+
+                let nodes = self.nodes.max(1000) as f64;
+                let diff = self.trend - pv.score().get() as f64;
+                let focus = self.attention.nodes(evaluator, head).get() as f64 / nodes;
+                let scale = 1. + magnitude * diff / (diff.abs() + pivot);
+                if time >= self.time.start * scale * (delta - gamma * focus) {
+                    return ControlFlow::Stop;
+                }
             }
         }
 
-        if stop.load(Relaxed) {
-            ControlFlow::Stop
-        } else {
-            ControlFlow::Continue
-        }
+        ControlFlow::Continue
     }
 }
 
@@ -168,72 +178,82 @@ mod tests {
 
     #[proptest]
     fn measures_time_elapsed(pos: Evaluator, l: Limits) {
-        let ctrl = Control::new(&pos, l);
+        let ctrl = GlobalControl::new(&pos, l);
         let duration = Duration::from_millis(1);
         thread::sleep(duration);
-        assert!(ctrl.time() >= duration);
+        assert!(ctrl.elapsed() >= duration);
     }
 
     #[proptest]
     fn time_elapsed_is_always_positive(pos: Evaluator, l: Limits) {
-        let ctrl = Control::new(&pos, l);
-        assert!(ctrl.time() > Duration::ZERO);
+        let ctrl = GlobalControl::new(&pos, l);
+        assert!(ctrl.elapsed() > Duration::ZERO);
     }
 
     #[proptest]
     fn aborts_if_time_is_up(pos: Evaluator, #[filter(#pv.head().is_some())] pv: Pv) {
-        let ctrl = Control::new(&pos, Limits::time(Duration::ZERO));
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Abort);
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Abort);
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Abort);
+        let global = GlobalControl::new(&pos, Limits::time(Duration::ZERO));
+        let mut local = LocalControl::new(&global);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Abort);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Abort);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Abort);
     }
 
     #[proptest]
     fn stops_if_searched_for_sufficient_time(
-        pos: Evaluator,
+        #[filter(#pos.ply() == 0)] pos: Evaluator,
         #[filter(#pv.head().is_some())] pv: Pv,
     ) {
-        let mut ctrl = Control::new(&pos, Limits::clock(Duration::MAX, Duration::ZERO));
-        ctrl.time.start = 0.;
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Stop);
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Stop);
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Stop);
+        let mut global = GlobalControl::new(&pos, Limits::clock(Duration::MAX, Duration::ZERO));
+        global.time.start = 0.;
+
+        let mut local = LocalControl::new(&global);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Stop);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Stop);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Stop);
     }
 
     #[proptest]
     fn counts_nodes_searched(pos: Evaluator, n: u64, #[filter(#pv.head().is_some())] pv: Pv) {
-        let ctrl = Control::new(&pos, Limits::nodes(n));
-        assert_eq!(ctrl.nodes(), 0);
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Continue);
-        assert_eq!(ctrl.nodes(), 1);
+        let global = GlobalControl::new(&pos, Limits::nodes(n));
+        let mut local = LocalControl::new(&global);
+        assert_eq!(local.visited(), 0);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Continue);
+        assert_eq!(local.visited(), 1);
     }
 
     #[proptest]
     fn aborts_if_node_count_is_reached(pos: Evaluator, #[filter(#pv.head().is_some())] pv: Pv) {
-        let ctrl = Control::new(&pos, Limits::nodes(0));
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Abort);
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Abort);
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Abort);
+        let global = GlobalControl::new(&pos, Limits::nodes(0));
+        let mut local = LocalControl::new(&global);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Abort);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Abort);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Abort);
     }
 
     #[proptest]
     fn aborts_upon_request(pos: Evaluator, #[filter(#pv.head().is_some())] pv: Pv) {
-        let ctrl = Control::new(&pos, Limits::none());
-        ctrl.abort();
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Abort);
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Abort);
-        assert_eq!(ctrl.check(&pv, pos.ply()), ControlFlow::Abort);
+        let global = GlobalControl::new(&pos, Limits::none());
+        global.abort();
+
+        let mut local = LocalControl::new(&global);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Abort);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Abort);
+        assert_eq!(local.check(&pv, &pos), ControlFlow::Abort);
     }
 
     #[proptest]
     fn suspends_limits_while_empty_pv(pos: Evaluator, s: Score) {
-        let ctrl = Control::new(&pos, Limits::time(Duration::ZERO));
-        assert_eq!(ctrl.check(&Pv::empty(s), pos.ply()), ControlFlow::Continue);
+        let global = GlobalControl::new(&pos, Limits::time(Duration::ZERO));
+        let mut local = LocalControl::new(&global);
+        assert_eq!(local.check(&Pv::empty(s), &pos), ControlFlow::Continue);
 
-        let ctrl = Control::new(&pos, Limits::clock(Duration::ZERO, Duration::ZERO));
-        assert_eq!(ctrl.check(&Pv::empty(s), pos.ply()), ControlFlow::Continue);
+        let global = GlobalControl::new(&pos, Limits::clock(Duration::ZERO, Duration::ZERO));
+        let mut local = LocalControl::new(&global);
+        assert_eq!(local.check(&Pv::empty(s), &pos), ControlFlow::Continue);
 
-        let ctrl = Control::new(&pos, Limits::nodes(0));
-        assert_eq!(ctrl.check(&Pv::empty(s), pos.ply()), ControlFlow::Continue);
+        let global = GlobalControl::new(&pos, Limits::nodes(0));
+        let mut local = LocalControl::new(&global);
+        assert_eq!(local.check(&Pv::empty(s), &pos), ControlFlow::Continue);
     }
 }

--- a/lib/search/statistics.rs
+++ b/lib/search/statistics.rs
@@ -102,6 +102,20 @@ impl<T: Stat> Stat for Option<T> {
     }
 }
 
+impl<T: Stat> Stat for NonNull<T> {
+    type Value = T::Value;
+
+    #[inline(always)]
+    fn get(&mut self) -> Self::Value {
+        self.assume().get()
+    }
+
+    #[inline(always)]
+    fn update(&mut self, delta: Self::Value) {
+        self.assume().update(delta);
+    }
+}
+
 /// A saturating accumulator that implements the "gravity" formula.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
@@ -115,7 +129,7 @@ unsafe impl<const MIN: i16, const MAX: i16> Integer for Graviton<MIN, MAX> {
 }
 
 impl<const MIN: i16, const MAX: i16> Stat for Graviton<MIN, MAX> {
-    type Value = i16;
+    type Value = <Self as Integer>::Repr;
 
     #[inline(always)]
     fn get(&mut self) -> Self::Value {


### PR DESCRIPTION
## SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 400000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 6.14 +/- 3.55, nElo: 10.16 +/- 5.87
LOS: 99.97 %, DrawRatio: 45.99 %, PairsRatio: 1.12
Games: 13460, Wins: 3729, Losses: 3491, Draws: 6240, Points: 6849.0 (50.88 %)
Ptnml(0-2): [199, 1517, 3095, 1685, 234], WL/DD Ratio: 1.04
LLR: 2.89 (100.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```