### PR TITLE
Decouple futility pruning from history heuristic

### DIFF
--- a/lib/params.rs
+++ b/lib/params.rs
@@ -201,8 +201,6 @@ params! {
     futility_margin_is_check: Variable1<{ [29237] }>,
     futility_margin_is_killer: Variable1<{ [27284] }>,
     futility_margin_improving: Variable1<{ [15524] }>,
-    futility_margin_history: Variable1<{ [18938] }>,
-    futility_margin_counter: Variable1<{ [20506] }>,
     futility_margin_gain: Variable1<{ [5587] }>,
     single_extension_margin_depth: Variable2<{ [0, 3074] }>,
     single_extension_margin_scalar: Variable1<{ [2013] }>,

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -607,8 +607,6 @@ impl<'a> Stack<'a> {
             futility += is_killer as i64 * Params::futility_margin_is_killer()[0];
 
             futility += improving * Params::futility_margin_improving()[0] / Params::BASE;
-            futility += history * Params::futility_margin_history()[0] / History::LIMIT as i64;
-            futility += counter * Params::futility_margin_counter()[0] / History::LIMIT as i64;
             futility += gain * Params::futility_margin_gain()[0];
 
             if self.value[ply.cast::<usize>()] + futility.max(0) / Params::BASE <= alpha {


### PR DESCRIPTION
## SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 400000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 2.25 +/- 1.79, nElo: 3.76 +/- 3.00
LOS: 99.30 %, DrawRatio: 46.02 %, PairsRatio: 1.04
Games: 51526, Wins: 13709, Losses: 13376, Draws: 24441, Points: 25929.5 (50.32 %)
Ptnml(0-2): [730, 6072, 11857, 6343, 761], WL/DD Ratio: 0.97
LLR: 2.89 (100.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```