### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "cinder"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cinder"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Bruno Dutra <brunocodutra@gmail.com>"]
 edition = "2024"
 description = "A chess engine"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CRATE_VERSION := 0.2.0
+CRATE_VERSION := 0.3.0
 TARGET_DIR := $(CURDIR)/target
 BIN_DIR := $(TARGET_DIR)/bin
 

--- a/README.md
+++ b/README.md
@@ -23,23 +23,23 @@ directly on a terminal via its command line interface (CLI).
 
 ```
 uci
-id name Cinder 0.2.0
+id name Cinder 0.3.0
 id author Bruno Dutra
 option name Hash type spin default 16 min 0 max 33554432
 option name Threads type spin default 1 min 1 max 4096
 option name SyzygyPath type string default <empty>
 uciok
 go depth 8
-info depth 0 time 0 nodes 0 nps 0 score cp 14 pv g1h3
-info depth 1 time 0 nodes 5 nps 84373 score cp 14 pv g1f3
-info depth 2 time 0 nodes 11 nps 165115 score cp 14 pv g1f3
-info depth 3 time 0 nodes 24 nps 312825 score cp 14 pv g1f3 g8f6
-info depth 4 time 0 nodes 89 nps 801224 score cp 18 pv e2e4 g8f6
-info depth 5 time 0 nodes 194 nps 1033008 score cp 11 pv e2e4 e7e5 b1c3
-info depth 6 time 0 nodes 360 nps 1377826 score cp 11 pv e2e4 e7e5 b1c3 g8f6
-info depth 7 time 0 nodes 819 nps 1647486 score cp 26 pv e2e4 e7e5 g1f3 g8f6 d2d4
-info depth 8 time 1 nodes 2933 nps 2159089 score cp 16 pv e2e4 c7c5 d2d4 c5d4 g1f3 b8c6 f3d4
-bestmove e2e4
+info depth 0 time 0 nodes 0 nps 0 score cp 14 pv a2a3
+info depth 1 time 0 nodes 0 nps 0 score cp 1 pv b2b3
+info depth 2 time 0 nodes 0 nps 0 score cp 12 pv c2c4
+info depth 3 time 0 nodes 0 nps 0 score cp 20 pv d2d4 c7c6
+info depth 4 time 0 nodes 0 nps 0 score cp 16 pv e2e4 e7e5
+info depth 5 time 0 nodes 0 nps 0 score cp 19 pv d2d4 d7d5 c2c4 d5c4
+info depth 6 time 0 nodes 0 nps 0 score cp 15 pv d2d4 d7d5 c2c4 d5c4 g1f3
+info depth 7 time 1 nodes 0 nps 0 score cp 30 pv e2e4 d7d5 e4d5 d8d5
+info depth 8 time 1 nodes 2048 nps 1250985 score cp 21 pv d2d4 d7d5 c2c4 c7c6 b1c3 g8f6 g1f3
+bestmove d2d4
 ```
 
 ## Acknowledgement


### PR DESCRIPTION
## VSTC

> `fastchess -games 2 -rounds 1000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=v0.3.0 cmd=engines/cinder-v0.3.0-linux-x86-64-v3 -engine name=v0.2.0 cmd=engines/cinder-v0.2.0-linux-x86-64-v3 -each tc=1+0.01`

```
--------------------------------------------------
Results of v0.3.0 vs v0.2.0 (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 52.42 +/- 6.70, nElo: 85.55 +/- 10.77
LOS: 100.00 %, DrawRatio: 40.15 %, PairsRatio: 2.48
Games: 4000, Wins: 1415, Losses: 816, Draws: 1769, Points: 2299.5 (57.49 %)
Ptnml(0-2): [32, 312, 803, 731, 122], WL/DD Ratio: 1.21
--------------------------------------------------
```

## STC

> `fastchess -games 2 -rounds 1000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=v0.3.0 cmd=engines/cinder-v0.3.0-linux-x86-64-v3 -engine name=v0.2.0 cmd=engines/cinder-v0.2.0-linux-x86-64-v3 -each tc=8+0.08`

```
--------------------------------------------------
Results of v0.3.0 vs v0.2.0 (8+0.08, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 62.42 +/- 5.76, nElo: 119.17 +/- 10.77
LOS: 100.00 %, DrawRatio: 43.70 %, PairsRatio: 3.77
Games: 4000, Wins: 1322, Losses: 611, Draws: 2067, Points: 2355.5 (58.89 %)
Ptnml(0-2): [5, 231, 874, 828, 62], WL/DD Ratio: 0.73
--------------------------------------------------
```

## LTC

> `fastchess -games 2 -rounds 1000 -openings file=engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /mnt/trunk/syzygy/ -draw movenumber=40 movecount=8 score=10 -concurrency 12 -use-affinity -recover -engine name=v0.3.0 cmd=engines/cinder-v0.3.0-linux-x86-64-v3 -engine name=v0.2.0 cmd=engines/cinder-v0.2.0-linux-x86-64-v3 -each tc=40+0.4`

```
--------------------------------------------------
Results of v0.3.0 vs v0.2.0 (40+0.4, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 71.16 +/- 10.64, nElo: 148.16 +/- 21.53
LOS: 100.00 %, DrawRatio: 43.60 %, PairsRatio: 5.56
Games: 1000, Wins: 336, Losses: 134, Draws: 530, Points: 601.0 (60.10 %)
Ptnml(0-2): [1, 42, 218, 232, 7], WL/DD Ratio: 0.70
--------------------------------------------------
```