### PR TITLE
Decouple see pruning from history and continuation heuristics

### DIFF
--- a/lib/params.rs
+++ b/lib/params.rs
@@ -215,8 +215,6 @@ params! {
     quiet_see_pruning_depth: Variable2<{ [-40119, -4118] }>,
     quiet_see_pruning_scalar: Variable1<{ [36777] }>,
     see_pruning_is_killer: Variable1<{ [-26725] }>,
-    see_pruning_history: Variable1<{ [-12145] }>,
-    see_pruning_counter: Variable1<{ [-23816] }>,
     late_move_reduction_depth: Variable3<{ [0, 947, 378] }>,
     late_move_reduction_index: Variable2<{ [0, 401] }>,
     late_move_reduction_scalar: Variable1<{ [3145] }>,

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -654,8 +654,6 @@ impl<'a> Stack<'a> {
             };
 
             spt += is_killer as i64 * Params::see_pruning_is_killer()[0];
-            spt += history * Params::see_pruning_history()[0] / History::LIMIT as i64;
-            spt += counter * Params::see_pruning_counter()[0] / History::LIMIT as i64;
             if !self.evaluator.winning(m, (spt / Params::BASE).saturate()) {
                 continue;
             }


### PR DESCRIPTION
## SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 25000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 2.54 +/- 1.97, nElo: 4.24 +/- 3.30
LOS: 99.41 %, DrawRatio: 45.16 %, PairsRatio: 1.04
Games: 42596, Wins: 11352, Losses: 11041, Draws: 20203, Points: 21453.5 (50.37 %)
Ptnml(0-2): [562, 5152, 9619, 5343, 622], WL/DD Ratio: 0.98
LLR: 2.90 (100.4%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```