### PR TITLE
Do not split continuation reply depending on whether the move is quiet

### DIFF
--- a/lib/search/continuation.rs
+++ b/lib/search/continuation.rs
@@ -5,7 +5,7 @@ use bytemuck::{Zeroable, zeroed};
 use derive_more::with_trait::Debug;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Zeroable)]
-pub struct Reply([[[<Reply as Statistics<Move>>::Stat; 64]; 2]; 6]);
+pub struct Reply([[<Reply as Statistics<Move>>::Stat; 64]; 6]);
 
 impl Default for Reply {
     #[inline(always)]
@@ -18,7 +18,7 @@ impl Reply {
     #[inline(always)]
     fn graviton(&mut self, pos: &Position, m: Move) -> &mut <Self as Statistics<Move>>::Stat {
         let role = pos.role_on(m.whence()).assume() as usize;
-        &mut self.0[role][m.is_quiet() as usize][m.whither() as usize]
+        &mut self.0[role][m.whither() as usize]
     }
 }
 
@@ -50,7 +50,7 @@ impl Default for Continuation {
 impl Continuation {
     #[inline(always)]
     pub fn reply(&mut self, pos: &Position, m: Move) -> &mut Reply {
-        let piece = pos.piece_on(m.whence()).assume() as usize;
-        &mut self.0[piece][m.is_quiet() as usize][m.whither() as usize]
+        let piece = pos.piece_on(m.whence()).assume();
+        &mut self.0[piece as usize][m.is_quiet() as usize][m.whither() as usize]
     }
 }

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -547,17 +547,15 @@ impl<'a> Stack<'a> {
                 return Bounded::upper();
             }
 
-            let mut rating = 0i64;
+            let mut rating = killer.contains(m) as i64 * Params::killer_move_bonus()[0];
             let history = self.searcher.history.get(&self.evaluator, m).cast::<i64>();
-            rating += Params::history_rating()[0] * history / History::LIMIT as i64;
+            rating += history * Params::history_rating()[0] / History::LIMIT as i64;
 
             let mut reply = self.replies.get_mut(ply.cast::<usize>().wrapping_sub(1));
             let counter = reply.get(&self.evaluator, m).cast::<i64>();
-            rating += Params::counter_rating()[0] * counter / History::LIMIT as i64;
+            rating += counter * Params::counter_rating()[0] / History::LIMIT as i64;
 
-            if killer.contains(m) {
-                rating += Params::killer_move_bonus()[0];
-            } else if !m.is_quiet() {
+            if !m.is_quiet() {
                 let gain = self.evaluator.gain(m);
                 if self.evaluator.winning(m, Value::new(1)) {
                     rating += convolve([
@@ -725,7 +723,7 @@ impl<'a> Stack<'a> {
 
             let mut rating = 0i64;
             let history = self.searcher.history.get(&self.evaluator, m).cast::<i64>();
-            rating += Params::history_rating()[0] * history / History::LIMIT as i64;
+            rating += history * Params::history_rating()[0] / History::LIMIT as i64;
 
             if !m.is_quiet() {
                 let gain = self.evaluator.gain(m);


### PR DESCRIPTION
## SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 25000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 3.11 +/- 2.29, nElo: 5.20 +/- 3.84
LOS: 99.61 %, DrawRatio: 45.53 %, PairsRatio: 1.05
Games: 31516, Wins: 8456, Losses: 8174, Draws: 14886, Points: 15899.0 (50.45 %)
Ptnml(0-2): [405, 3786, 7175, 3906, 486], WL/DD Ratio: 0.99
LLR: 2.90 (100.4%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```


