### PR TITLE
Reimplement lazy evaluation

### DIFF
--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -5,10 +5,16 @@ use bytemuck::zeroed;
 use derive_more::with_trait::Debug;
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, Index, Range};
-use std::{array, str::FromStr};
+use std::{array, hint::unreachable_unchecked, str::FromStr};
 
 #[cfg(test)]
 use proptest::{prelude::*, sample::*};
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Pending {
+    Update,
+    Refresh,
+}
 
 /// A [`Position`] evaluation stack.
 #[derive(Debug, Clone)]
@@ -18,6 +24,7 @@ pub struct Evaluator {
     positions: [Position; Ply::MAX as usize + 1],
     positional: [[Positional; 2]; Ply::MAX as usize + 1],
     material: [[Material; 2]; Ply::MAX as usize + 1],
+    pending: [[Option<Pending>; Ply::MAX as usize + 1]; 2],
     // move[i] leads to pos[i + 1]
     moves: [Option<Move>; Ply::MAX as usize],
 }
@@ -96,6 +103,7 @@ impl Evaluator {
             positions: array::from_fn(|_| Default::default()),
             positional: zeroed(),
             material: zeroed(),
+            pending: [[None; Ply::MAX as usize + 1]; 2],
             moves: [None; Ply::MAX as usize],
         };
 
@@ -121,64 +129,20 @@ impl Evaluator {
 
         self.ply += 1;
         self.moves[idx] = m;
+        self.pending[0][idx + 1] = Some(Pending::Update);
+        self.pending[1][idx + 1] = Some(Pending::Update);
         self.positions[idx + 1] = self.positions[idx].clone();
 
         match self.moves[idx] {
             None => self.positions[idx + 1].pass(),
-            Some(m) => self.positions[idx + 1].play(m),
-        }
-
-        for side in Color::iter() {
-            let mut sub = [None; 2];
-            let mut add = [None; 2];
-
-            if let Some(m) = self.moves[idx] {
+            Some(m) => {
+                self.positions[idx + 1].play(m);
                 let (wc, wt) = (m.whence(), m.whither());
-                let role = self.positions[idx].role_on(wc).assume();
-                if Piece::new(role, turn) == Piece::new(Role::King, side)
-                    && Feature::bucket(side, wc) != Feature::bucket(side, wt)
-                {
-                    self.refresh(turn, self.ply);
-                    continue;
-                }
-
-                let ksq = self.king(side);
-                let old = Piece::new(role, turn);
-                let new = Piece::new(m.promotion().unwrap_or(role), turn);
-                sub[0] = Some(Feature::new(side, ksq, old, wc));
-                add[0] = Some(Feature::new(side, ksq, new, wt));
-
-                let capture = match self.positions[idx].role_on(wt) {
-                    _ if !m.is_capture() => None,
-                    Some(r) => Some((r, wt)),
-                    None => Some((Role::Pawn, Square::new(wt.file(), wc.rank()))),
-                };
-
-                if let Some((r, sq)) = capture {
-                    let victim = Piece::new(r, !turn);
-                    sub[1] = Some(Feature::new(side, ksq, victim, sq));
-                } else if role == Role::King && (wt - wc).abs() == 2 {
-                    let rook = Piece::new(Role::Rook, turn);
-                    let (wc, wt) = if wt > wc {
-                        (Square::H1.perspective(turn), Square::F1.perspective(turn))
-                    } else {
-                        (Square::A1.perspective(turn), Square::D1.perspective(turn))
-                    };
-
-                    sub[1] = Some(Feature::new(side, ksq, rook, wc));
-                    add[1] = Some(Feature::new(side, ksq, rook, wt));
+                let role = self.positions[idx].role_on(m.whence()).assume();
+                if role == Role::King && Feature::bucket(turn, wc) != Feature::bucket(turn, wt) {
+                    self.pending[turn.cast::<usize>()][idx + 1] = Some(Pending::Refresh)
                 }
             }
-
-            let (left, right) = self.material.split_at_mut(idx + 1);
-            let src = &left[left.len() - 1][side.cast::<usize>()];
-            let dst = &mut right[0][side.cast::<usize>()];
-            Nnue::material().accumulate(src, dst, sub, add);
-
-            let (left, right) = self.positional.split_at_mut(idx + 1);
-            let src = &left[left.len() - 1][side.cast::<usize>()];
-            let dst = &mut right[0][side.cast::<usize>()];
-            Nnue::positional().accumulate(src, dst, sub, add);
         }
     }
 
@@ -188,15 +152,40 @@ impl Evaluator {
         self.ply -= 1;
     }
 
-    /// The value of the [`Position`] at current ply.
     pub fn evaluate(&mut self) -> Value {
+        for side in Color::iter() {
+            let mut idx = self.ply.cast::<usize>();
+            if self.pending[side.cast::<usize>()][idx].is_none() {
+                continue;
+            }
+
+            (self.ply > 0).assume();
+            while self.pending[side.cast::<usize>()][idx] == Some(Pending::Update) {
+                idx -= 1;
+            }
+
+            match self.pending[side.cast::<usize>()][idx] {
+                Some(Pending::Update) => unsafe { unreachable_unchecked() },
+                Some(Pending::Refresh) => self.refresh(side, self.ply),
+                None => {
+                    for i in idx + 1..=self.ply.cast::<usize>() {
+                        self.update(side, i.convert().assume());
+                    }
+                }
+            }
+        }
+
         let phase = self.phase();
         let out = Nnue::output(phase);
+
+        let phase = phase.cast::<usize>();
+        let idx = self.ply.cast::<usize>();
+        debug_assert_eq!(self.pending[0][idx], None);
+        debug_assert_eq!(self.pending[1][idx], None);
+
         let us = self.turn() as usize;
         let them = self.turn().flip() as usize;
-        let idx = self.ply.cast::<usize>();
-        let material = self.material[idx][us][phase.cast::<usize>()]
-            - self.material[idx][them][phase.cast::<usize>()];
+        let material = self.material[idx][us][phase] - self.material[idx][them][phase];
         let positional = out.forward(&self.positional[idx][us], &self.positional[idx][them]);
         let scale = Params::value_scale()[0] / Params::BASE;
         let value = (material + 2 * positional) as i64 / scale;
@@ -287,7 +276,7 @@ impl Evaluator {
 
     fn refresh(&mut self, side: Color, ply: Ply) {
         let idx = ply.cast::<usize>();
-
+        self.pending[side.cast::<usize>()][idx] = None;
         Nnue::material().refresh(&mut self.material[idx][side.cast::<usize>()]);
         Nnue::positional().refresh(&mut self.positional[idx][side.cast::<usize>()]);
 
@@ -299,6 +288,57 @@ impl Evaluator {
             let accumulator = &mut self.positional[idx][side.cast::<usize>()];
             Nnue::positional().accumulate_in_place(accumulator, [None; 2], add);
         }
+    }
+
+    fn update(&mut self, side: Color, ply: Ply) {
+        (ply > 0).assume();
+
+        let idx = ply.cast::<usize>();
+        self.pending[side.cast::<usize>()][idx] = None;
+
+        let mut sub = [None; 2];
+        let mut add = [None; 2];
+
+        if let Some(m) = self.moves[idx - 1] {
+            let pos = &self.positions[idx];
+            let prev = &self.positions[idx - 1];
+            let (wc, wt) = (m.whence(), m.whither());
+            let promotion = m.promotion();
+            let role = prev.role_on(wc).assume();
+            let turn = prev.turn();
+
+            let ksq = pos.king(side);
+            let old = Piece::new(role, turn);
+            let new = Piece::new(promotion.unwrap_or(role), turn);
+            sub[0] = Some(Feature::new(side, ksq, old, wc));
+            add[0] = Some(Feature::new(side, ksq, new, wt));
+
+            let capture = match prev.role_on(wt) {
+                _ if !m.is_capture() => None,
+                Some(r) => Some((r, wt)),
+                None => Some((Role::Pawn, Square::new(wt.file(), wc.rank()))),
+            };
+
+            if let Some((r, sq)) = capture {
+                let victim = Piece::new(r, !turn);
+                sub[1] = Some(Feature::new(side, ksq, victim, sq));
+            } else if role == Role::King && (wt - wc).abs() == 2 {
+                let m = Castles::rook(wt);
+                let rook = Piece::new(Role::Rook, turn);
+                sub[1] = Some(Feature::new(side, ksq, rook, m.whence()));
+                add[1] = Some(Feature::new(side, ksq, rook, m.whither()));
+            }
+        }
+
+        let (left, right) = self.material.split_at_mut(idx);
+        let src = &left[left.len() - 1][side.cast::<usize>()];
+        let dst = &mut right[0][side.cast::<usize>()];
+        Nnue::material().accumulate(src, dst, sub, add);
+
+        let (left, right) = self.positional.split_at_mut(idx);
+        let src = &left[left.len() - 1][side.cast::<usize>()];
+        let dst = &mut right[0][side.cast::<usize>()];
+        Nnue::positional().accumulate(src, dst, sub, add);
     }
 }
 


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 2.10 +/- 1.68, nElo: 3.63 +/- 2.91
LOS: 99.27 %, DrawRatio: 48.60 %, PairsRatio: 1.04
Games: 54798, Wins: 14550, Losses: 14219, Draws: 26029, Points: 27564.5 (50.30 %)
Ptnml(0-2): [692, 6201, 13316, 6464, 726], WL/DD Ratio: 0.99
LLR: 2.90 (100.3%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```