### PR TITLE
Decouple reverse futility pruning from cut node and noisy pv heuristics

### DIFF
--- a/lib/params.rs
+++ b/lib/params.rs
@@ -196,8 +196,6 @@ params! {
     reverse_futility_margin_depth: Variable2<{ [5250, 48192] }>,
     reverse_futility_margin_scalar: Variable1<{ [36518] }>,
     reverse_futility_margin_improving: Variable1<{ [-22725] }>,
-    reverse_futility_margin_is_noisy_pv: Variable1<{ [-4246] }>,
-    reverse_futility_margin_cut: Variable1<{ [-10858] }>,
     futility_margin_depth: Variable2<{ [7783, 116394] }>,
     futility_margin_scalar: Variable1<{ [241533] }>,
     futility_margin_is_pv: Variable1<{ [29737] }>,

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -516,8 +516,6 @@ impl<'a> Stack<'a> {
 
             if let Some(mut margin) = Self::rfp(depth) {
                 margin += improving * Params::reverse_futility_margin_improving()[0] / Params::BASE;
-                margin += is_noisy_pv as i64 * Params::reverse_futility_margin_is_noisy_pv()[0];
-                margin += cut as i64 * Params::reverse_futility_margin_cut()[0];
                 if transposed.score() - margin / Params::BASE >= beta {
                     return Ok(transposed.truncate());
                 }


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 0.57 +/- 1.91, nElo: 0.96 +/- 3.22
LOS: 71.96 %, DrawRatio: 46.11 %, PairsRatio: 1.01
Games: 44680, Wins: 11828, Losses: 11755, Draws: 21097, Points: 22376.5 (50.08 %)
Ptnml(0-2): [615, 5372, 10301, 5429, 623], WL/DD Ratio: 1.00
LLR: 2.90 (100.2%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```