### PR TITLE
Do not split continuation ply depending on whether the move is quiet

### DIFF
--- a/lib/search/continuation.rs
+++ b/lib/search/continuation.rs
@@ -38,7 +38,7 @@ impl Statistics<Move> for Reply {
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Zeroable)]
 #[debug("Continuation")]
-pub struct Continuation([[[Reply; 64]; 2]; 12]);
+pub struct Continuation([[Reply; 64]; 12]);
 
 impl Default for Continuation {
     #[inline(always)]
@@ -51,6 +51,6 @@ impl Continuation {
     #[inline(always)]
     pub fn reply(&mut self, pos: &Position, m: Move) -> &mut Reply {
         let piece = pos.piece_on(m.whence()).assume();
-        &mut self.0[piece as usize][m.is_quiet() as usize][m.whither() as usize]
+        &mut self.0[piece as usize][m.whither() as usize]
     }
 }


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 5.84 +/- 3.46, nElo: 9.60 +/- 5.68
LOS: 99.95 %, DrawRatio: 44.20 %, PairsRatio: 1.12
Games: 14390, Wins: 3914, Losses: 3672, Draws: 6804, Points: 7316.0 (50.84 %)
Ptnml(0-2): [210, 1688, 3180, 1884, 233], WL/DD Ratio: 0.97
LLR: 2.89 (100.0%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```