### PR TITLE
Improve fn Position::exchanges to account for pins to some extent

### DIFF
--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -431,7 +431,7 @@ mod tests {
         ("5rk1/1pp2q1p/p1pb4/8/3P1NP1/2P5/1P1BQ1P1/5RK1 b - - 0 1", "d6f4", -25),
         ("5rk1/5pp1/2r4p/5b2/2R5/6Q1/R1P1qPP1/5NK1 b - - 0 1", "f5c2", -137),
         ("6k1/1pp4p/p1pb4/6q1/3P1pRr/2P4P/PP1Br1P1/5RKN w - - 0 1", "f1f4", -59),
-        ("6r1/4kq2/b2p1p2/p1pPb3/p1P2B1Q/2P4P/2B1R1P1/6K1 w - - 0 1", "f4e5", 0),
+        ("6r1/4kq2/b2p1p2/p1pPb3/p1P2B1Q/2P4P/2B1R1P1/6K1 w - - 0 1", "f4e5", 59),
         ("6RR/4bP2/8/8/5r2/3K4/5p2/4k3 w - - 0 1", "f7f8n", 136),
         ("6RR/4bP2/8/8/5r2/3K4/5p2/4k3 w - - 0 1", "f7f8q", 159),
         ("6rr/6pk/p1Qp1b1p/2n5/1B3p2/5p2/P1P2P2/4RK1R w - - 0 1", "e1e8", -334),


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 40000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 2.29 +/- 1.83, nElo: 3.81 +/- 3.03
LOS: 99.31 %, DrawRatio: 44.89 %, PairsRatio: 1.04
Games: 50422, Wins: 13485, Losses: 13152, Draws: 23785, Points: 25377.5 (50.33 %)
Ptnml(0-2): [711, 6090, 11318, 6339, 753], WL/DD Ratio: 0.99
LLR: 2.90 (100.2%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```