### PR TITLE
Incorporate threats to history heuristic 

### DIFF
--- a/lib/chess/piece.rs
+++ b/lib/chess/piece.rs
@@ -180,11 +180,11 @@ impl Piece {
     /// This piece's possible moves from a given square.
     #[inline(always)]
     pub fn moves(&self, wc: Square, ours: Bitboard, theirs: Bitboard) -> Bitboard {
-        let occupied = ours | theirs;
+        let occ = ours | theirs;
         if self.role() != Role::Pawn {
-            self.attacks(wc, occupied) & !ours
+            self.attacks(wc, occ) & !ours
         } else {
-            let empty = !occupied;
+            let empty = !occ;
             let color = self.color();
             let third = Rank::Third.bitboard();
             let push = wc.bitboard().perspective(color).shl(8).perspective(color) & empty;

--- a/lib/search/history.rs
+++ b/lib/search/history.rs
@@ -6,7 +6,8 @@ use derive_more::with_trait::Debug;
 /// Historical statistics about a [`Move`].
 #[derive(Debug, Zeroable)]
 #[debug("History")]
-pub struct History([[Butterfly<<History as Statistics<Move>>::Stat>; 2]; 2]);
+#[allow(clippy::type_complexity)]
+pub struct History([[Butterfly<[[<History as Statistics<Move>>::Stat; 2]; 2]>; 2]; 2]);
 
 impl Default for History {
     #[inline(always)]
@@ -20,8 +21,11 @@ impl History {
 
     #[inline(always)]
     fn graviton(&mut self, pos: &Position, m: Move) -> &mut <Self as Statistics<Move>>::Stat {
-        let (wc, wt) = (m.whence() as usize, m.whither() as usize);
-        &mut self.0[pos.turn() as usize][m.is_quiet() as usize][wc][wt]
+        let (wc, wt) = (m.whence(), m.whither());
+        let evading = pos.threats().contains(wc);
+        let surrendering = pos.threats().contains(wt);
+        &mut self.0[pos.turn() as usize][m.is_quiet() as usize][wc as usize][wt as usize]
+            [evading as usize][surrendering as usize]
     }
 }
 


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 10.16 +/- 4.74, nElo: 16.61 +/- 7.75
LOS: 100.00 %, DrawRatio: 44.44 %, PairsRatio: 1.20
Games: 7728, Wins: 2151, Losses: 1925, Draws: 3652, Points: 3977.0 (51.46 %)
Ptnml(0-2): [109, 869, 1717, 1025, 144], WL/DD Ratio: 0.95
LLR: 2.89 (100.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```