### PR TITLE
Consider squares covered by the king to be threatened

### DIFF
--- a/lib/chess/piece.rs
+++ b/lib/chess/piece.rs
@@ -180,7 +180,7 @@ impl Piece {
     /// This piece's possible moves from a given square.
     #[inline(always)]
     pub fn moves(&self, wc: Square, ours: Bitboard, theirs: Bitboard) -> Bitboard {
-        let occ = ours | theirs;
+        let occ = ours ^ theirs;
         if self.role() != Role::Pawn {
             self.attacks(wc, occ) & !ours
         } else {


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 2.11 +/- 2.89, nElo: 3.59 +/- 4.92
LOS: 92.34 %, DrawRatio: 47.76 %, PairsRatio: 1.03
Games: 19132, Wins: 5136, Losses: 5020, Draws: 8976, Points: 9624.0 (50.30 %)
Ptnml(0-2): [246, 2215, 4569, 2249, 287], WL/DD Ratio: 1.03
LLR: 2.91 (100.6%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```