### PR TITLE
Allow tablebase probing on all node types

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -476,8 +476,6 @@ impl<'a> Stack<'a> {
 
         let (lower, upper) = if depth <= 0 {
             (transposed.score(), Score::upper())
-        } else if !is_pv {
-            (Score::lower(), Score::upper())
         } else {
             match self.syzygy.wdl_after_zeroing(&self.evaluator) {
                 None => (Score::lower(), Score::upper()),


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 3.13 +/- 2.29, nElo: 5.36 +/- 3.91
LOS: 99.64 %, DrawRatio: 47.55 %, PairsRatio: 1.06
Games: 30370, Wins: 8216, Losses: 7942, Draws: 14212, Points: 15322.0 (50.45 %)
Ptnml(0-2): [393, 3464, 7221, 3690, 417], WL/DD Ratio: 1.05
LLR: 2.91 (100.7%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```