### PR TITLE
Filter out transpositions with illegal moves

### DIFF
--- a/lib/chess/castles.rs
+++ b/lib/chess/castles.rs
@@ -1,9 +1,8 @@
 use crate::chess::{Color, Move, Perspective, Piece, Role, Square};
-use crate::util::{Bits, Integer, bits};
+use crate::util::{Assume, Bits, Integer, bits};
 use bytemuck::{Zeroable, zeroed};
 use derive_more::with_trait::{Debug, *};
 use std::fmt::{self, Formatter};
-use std::hint::unreachable_unchecked;
 use std::{cell::SyncUnsafeCell, str::FromStr};
 
 /// The castling rights in a chess [`Position`][`crate::chess::Position`].
@@ -43,13 +42,13 @@ impl Castles {
 
     /// The rook's [`Move`] given the king's castling [`Square`].
     #[inline(always)]
-    pub fn rook(castling: Square) -> Move {
+    pub fn rook(castling: Square) -> Option<Move> {
         match castling {
-            Square::C1 => Move::regular(Square::A1, Square::D1, None),
-            Square::G1 => Move::regular(Square::H1, Square::F1, None),
-            Square::C8 => Move::regular(Square::A8, Square::D8, None),
-            Square::G8 => Move::regular(Square::H8, Square::F8, None),
-            _ => unsafe { unreachable_unchecked() },
+            Square::C1 => Some(Move::regular(Square::A1, Square::D1, None)),
+            Square::G1 => Some(Move::regular(Square::H1, Square::F1, None)),
+            Square::C8 => Some(Move::regular(Square::A8, Square::D8, None)),
+            Square::G8 => Some(Move::regular(Square::H8, Square::F8, None)),
+            _ => None,
         }
     }
 
@@ -62,7 +61,7 @@ impl Castles {
     /// Whether the rights for the given castling square.
     #[inline(always)]
     pub fn has(&self, sq: Square) -> bool {
-        *self & Castles::from(Castles::rook(sq).whence()) != Castles::none()
+        *self & Castles::from(Castles::rook(sq).assume().whence()) != Castles::none()
     }
 }
 

--- a/lib/chess/move.rs
+++ b/lib/chess/move.rs
@@ -6,6 +6,7 @@ use std::{num::NonZeroU16, ops::RangeBounds};
 /// A chess move.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
+#[cfg_attr(test, filter(#self.is_promotion() || #self.bits(..2) == Bits::new(0)))]
 pub struct Move(NonZeroU16);
 
 impl Move {

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -323,7 +323,7 @@ impl Evaluator {
                 let victim = Piece::new(r, !turn);
                 sub[1] = Some(Feature::new(side, ksq, victim, sq));
             } else if role == Role::King && (wt - wc).abs() == 2 {
-                let m = Castles::rook(wt);
+                let m = Castles::rook(wt).assume();
                 let rook = Piece::new(Role::Rook, turn);
                 sub[1] = Some(Feature::new(side, ksq, rook, m.whence()));
                 add[1] = Some(Feature::new(side, ksq, rook, m.whither()));

--- a/lib/uci.rs
+++ b/lib/uci.rs
@@ -491,8 +491,8 @@ mod tests {
 
     #[proptest]
     fn ignores_position_with_invalid_move(
-        #[strategy("[^[:ascii:]]+")] _s: String,
         #[any(StaticStream::new([format!("position startpos moves {}", #_s)]))] mut uci: MockUci,
+        #[strategy("[^[:ascii:]]+")] _s: String,
     ) {
         let pos = uci.position.clone();
         assert_eq!(block_on(uci.run()), Ok(()));
@@ -502,9 +502,8 @@ mod tests {
 
     #[proptest]
     fn handles_position_with_illegal_move(
-        #[filter(!Position::default().moves().unpack().any(|m| UciMove(m) == *#_m.to_string()))]
-        _m: Move,
         #[any(StaticStream::new([format!("position startpos moves {}", #_m)]))] mut uci: MockUci,
+        #[filter(!Position::default().is_legal(#_m))] _m: Move,
     ) {
         let pos = uci.position.clone();
         assert_eq!(block_on(uci.run()), Ok(()));


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 1.05 +/- 2.24, nElo: 1.80 +/- 3.86
LOS: 82.02 %, DrawRatio: 48.07 %, PairsRatio: 1.02
Games: 31192, Wins: 8265, Losses: 8171, Draws: 14756, Points: 15643.0 (50.15 %)
Ptnml(0-2): [400, 3607, 7497, 3683, 409], WL/DD Ratio: 1.01
LLR: 2.90 (100.2%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```