### PR TITLE
Update fn Position::exchanges to fully account for pins

### DIFF
--- a/lib/chess/board.rs
+++ b/lib/chess/board.rs
@@ -139,9 +139,9 @@ impl Board {
 
     /// Squares occupied by pinned [`Piece`]s of a [`Color`].
     #[inline(always)]
-    pub fn pinned(&self, c: Color) -> Bitboard {
-        let ours = self.material(c);
-        let theirs = self.material(!c);
+    pub fn pinned(&self, c: Color, mask: Bitboard) -> Bitboard {
+        let ours = mask & self.material(c);
+        let theirs = mask & self.material(!c);
         let occ = ours ^ theirs;
 
         let king = self.king(c).assume();


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 3.95 +/- 3.76, nElo: 6.67 +/- 6.37
LOS: 98.01 %, DrawRatio: 46.02 %, PairsRatio: 1.07
Games: 11444, Wins: 3100, Losses: 2970, Draws: 5374, Points: 5787.0 (50.57 %)
Ptnml(0-2): [142, 1348, 2633, 1436, 163], WL/DD Ratio: 1.03
LLR: 2.91 (100.7%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```