### PR TITLE
Incorporate threats to continuation heuristic

### DIFF
--- a/lib/chess.rs
+++ b/lib/chess.rs
@@ -31,3 +31,9 @@ pub use rank::*;
 pub use role::*;
 pub use square::*;
 pub use zobrist::*;
+
+/// The butterfly board.
+pub type Butterfly<T> = [[T; 64]; 64];
+
+/// The piece-to board.
+pub type PieceTo<T> = [[T; 64]; 12];

--- a/lib/chess/bitboard.rs
+++ b/lib/chess/bitboard.rs
@@ -1,12 +1,9 @@
-use crate::chess::{File, Flip, Rank, Square};
+use crate::chess::{Butterfly, File, Flip, Rank, Square};
 use crate::util::{Assume, Integer};
 use bytemuck::{Zeroable, zeroed};
 use derive_more::with_trait::{Debug, *};
 use std::cell::SyncUnsafeCell;
 use std::fmt::{self, Formatter, Write};
-
-/// The butterfly board.
-pub type Butterfly<T> = [[T; 64]; 64];
 
 /// A set of squares on a chess board.
 #[derive(

--- a/lib/chess/zobrist.rs
+++ b/lib/chess/zobrist.rs
@@ -9,7 +9,7 @@ pub type Zobrist = Bits<u64, 64>;
 
 #[derive(Debug, Zeroable)]
 pub struct ZobristNumbers {
-    pieces: [[u64; 64]; 12],
+    pieces: PieceTo<u64>,
     castles: [u64; 16],
     en_passant: [u64; 8],
     turn: u64,

--- a/lib/search/history.rs
+++ b/lib/search/history.rs
@@ -22,10 +22,9 @@ impl History {
     #[inline(always)]
     fn graviton(&mut self, pos: &Position, m: Move) -> &mut <Self as Statistics<Move>>::Stat {
         let (wc, wt) = (m.whence(), m.whither());
-        let evading = pos.threats().contains(wc);
-        let surrendering = pos.threats().contains(wt);
+        let threats = [pos.threats().contains(wc), pos.threats().contains(wt)];
         &mut self.0[pos.turn() as usize][m.is_quiet() as usize][wc as usize][wt as usize]
-            [evading as usize][surrendering as usize]
+            [threats[0] as usize][threats[1] as usize]
     }
 }
 


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 1.58 +/- 1.66, nElo: 2.64 +/- 2.78
LOS: 96.84 %, DrawRatio: 45.35 %, PairsRatio: 1.02
Games: 60000, Wins: 16093, Losses: 15821, Draws: 28086, Points: 30136.0 (50.23 %)
Ptnml(0-2): [797, 7307, 13604, 7411, 881], WL/DD Ratio: 1.04
LLR: 1.69 (58.6%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```