### PR TITLE
Avoid pruning nodes based on transposition score near 50-move horizon

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -477,18 +477,20 @@ impl<'a> Stack<'a> {
             t.best().is_some_and(|m| !m.is_quiet()) && !matches!(t.score(), ScoreBound::Upper(_))
         });
 
-        if let Some(t) = transposition {
-            let (lower, upper) = t.score().range(ply).into_inner();
+        if !is_pv && self.evaluator.halfmoves() < 90 {
+            if let Some(t) = transposition {
+                let (lower, upper) = t.score().range(ply).into_inner();
 
-            if let Some(margin) = Self::flp(depth - t.depth()) {
-                if !is_pv && upper + margin / Params::BASE <= alpha {
-                    return Ok(transposed.truncate());
+                if let Some(margin) = Self::flp(depth - t.depth()) {
+                    if upper + margin / Params::BASE <= alpha {
+                        return Ok(transposed.truncate());
+                    }
                 }
-            }
 
-            if let Some(margin) = Self::fhp(depth - t.depth()) {
-                if !is_pv && lower - margin / Params::BASE >= beta {
-                    return Ok(transposed.truncate());
+                if let Some(margin) = Self::fhp(depth - t.depth()) {
+                    if lower - margin / Params::BASE >= beta {
+                        return Ok(transposed.truncate());
+                    }
                 }
             }
         }


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 2.98 +/- 2.21, nElo: 5.11 +/- 3.79
LOS: 99.59 %, DrawRatio: 47.87 %, PairsRatio: 1.06
Games: 32278, Wins: 8780, Losses: 8503, Draws: 14995, Points: 16277.5 (50.43 %)
Ptnml(0-2): [416, 3669, 7725, 3880, 449], WL/DD Ratio: 1.07
LLR: 2.89 (100.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```