### PR TITLE
Increase transposition depth of syzygy scores

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -508,7 +508,7 @@ impl<'a> Stack<'a> {
                     };
 
                     if score.upper(ply) <= alpha || score.lower(ply) >= beta {
-                        let transposition = Transposition::new(score, depth, None, was_pv);
+                        let transposition = Transposition::new(score, depth + 4, None, was_pv);
                         self.tt.set(self.evaluator.zobrists().hash, transposition);
                         return Ok(transposition.transpose(ply).truncate());
                     }


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 2.76 +/- 2.09, nElo: 4.76 +/- 3.60
LOS: 99.52 %, DrawRatio: 48.28 %, PairsRatio: 1.06
Games: 35786, Wins: 9545, Losses: 9261, Draws: 16980, Points: 18035.0 (50.40 %)
Ptnml(0-2): [450, 4045, 8638, 4291, 469], WL/DD Ratio: 1.00
LLR: 2.90 (100.3%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```