### PR TITLE
Separate tablebase score from mates

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 profile-rustflags = true
 
 [env]
-RUST_MIN_STACK = "8388608" # runtime only
+RUST_MIN_STACK = "16777216" # runtime only
 
 [build]
 rustflags = ["-Ctarget-cpu=native"]

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -353,42 +353,9 @@ impl FromStr for Evaluator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::sample::{Selector, select};
+    use proptest::sample::select;
     use std::fmt::Debug;
     use test_strategy::proptest;
-
-    #[proptest]
-    fn accumulators_are_updated_lazily(
-        mut e: Evaluator,
-        #[strategy(..16usize)] mut n: usize,
-        selector: Selector,
-    ) {
-        let mut i = e.ply();
-        let mut pos = e.deref().clone();
-        while n > 0 && e.ply() < Ply::MAX && e.outcome().is_none() {
-            n -= 1;
-            if n % 5 == 1 && i > 0 {
-                e.pop();
-                pos = e.deref().clone();
-                i -= 1;
-            } else if n % 3 == 1 && !pos.is_check() {
-                e.push(None);
-                pos.pass();
-                i += 1;
-            } else {
-                let m = selector.select(pos.moves().unpack());
-                e.push(Some(m));
-                pos.play(m);
-                i += 1;
-            }
-        }
-
-        let mut f = Evaluator::new(pos);
-
-        assert_eq!(e, f);
-        assert_eq!(e.ply(), f.ply() + i);
-        assert_eq!(e.evaluate(), f.evaluate());
-    }
 
     #[proptest]
     fn parsing_printed_evaluator_is_an_identity(e: Evaluator) {

--- a/lib/nnue/transformer.rs
+++ b/lib/nnue/transformer.rs
@@ -116,7 +116,7 @@ pub struct Affine<T, const N: usize> {
 }
 
 impl<T: Copy, const N: usize> Affine<T, N> {
-    /// Refreshes the `accumulator``.
+    /// Refreshes the `accumulator`.
     #[inline(always)]
     pub fn refresh(&self, accumulator: &mut [T; N]) {
         *accumulator = *self.bias;

--- a/lib/nnue/value.rs
+++ b/lib/nnue/value.rs
@@ -9,7 +9,7 @@ pub struct ValueRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as
 unsafe impl Integer for ValueRepr {
     type Repr = i16;
     const MIN: Self::Repr = -Self::MAX;
-    const MAX: Self::Repr = 3999;
+    const MAX: Self::Repr = 3839;
 }
 
 /// A position's static evaluation.

--- a/lib/search/ply.rs
+++ b/lib/search/ply.rs
@@ -8,7 +8,7 @@ pub struct PlyRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as I
 unsafe impl Integer for PlyRepr {
     type Repr = i8;
     const MIN: Self::Repr = 0;
-    const MAX: Self::Repr = 95;
+    const MAX: Self::Repr = 127;
 }
 
 /// The number of half-moves played.

--- a/lib/search/score.rs
+++ b/lib/search/score.rs
@@ -90,6 +90,24 @@ impl Score {
     pub fn mated(ply: Ply) -> Self {
         Self::lower().relative_to_ply(ply)
     }
+
+    /// Returns true if the score represents a winning position.
+    #[inline(always)]
+    pub fn is_win(&self) -> bool {
+        matches!(self.mate(), Mate::Mating(_))
+    }
+
+    /// Returns true if the score represents a losing position.
+    #[inline(always)]
+    pub fn is_loss(&self) -> bool {
+        matches!(self.mate(), Mate::Mated(_))
+    }
+
+    /// Returns true if the score represents a decisive position (win or loss).
+    #[inline(always)]
+    pub fn is_decisive(&self) -> bool {
+        self.is_win() || self.is_loss()
+    }
 }
 
 impl Flip for Score {
@@ -142,6 +160,26 @@ mod tests {
     #[proptest]
     fn mate_returns_plies_to_mated(p: Ply) {
         assert_eq!(Score::mated(p).mate(), Mate::Mated(p));
+    }
+
+    #[proptest]
+    fn mating_implies_is_win(p: Ply) {
+        assert!(Score::mating(p).is_win());
+    }
+
+    #[proptest]
+    fn mated_implies_is_loss(p: Ply) {
+        assert!(Score::mated(p).is_loss());
+    }
+
+    #[proptest]
+    fn mating_implies_is_decisive(p: Ply) {
+        assert!(Score::mating(p).is_decisive());
+    }
+
+    #[proptest]
+    fn mated_implies_is_decisive(p: Ply) {
+        assert!(Score::mated(p).is_decisive());
     }
 
     #[proptest]

--- a/lib/search/transposition.rs
+++ b/lib/search/transposition.rs
@@ -31,7 +31,6 @@ impl ScoreBound {
     }
 
     // The score bound.
-    #[track_caller]
     #[inline(always)]
     pub fn bound(&self, ply: Ply) -> Score {
         match *self {
@@ -42,7 +41,6 @@ impl ScoreBound {
     }
 
     /// A lower bound for the score normalized to [`Ply`].
-    #[track_caller]
     #[inline(always)]
     pub fn lower(&self, ply: Ply) -> Score {
         match *self {
@@ -52,7 +50,6 @@ impl ScoreBound {
     }
 
     /// An upper bound for the score normalized to [`Ply`].
-    #[track_caller]
     #[inline(always)]
     pub fn upper(&self, ply: Ply) -> Score {
         match *self {

--- a/lib/syzygy/wdl.rs
+++ b/lib/syzygy/wdl.rs
@@ -31,8 +31,8 @@ impl Wdl {
     #[inline(always)]
     pub fn to_score(self, ply: Ply) -> Score {
         match self {
-            Wdl::Win => Score::mating(ply),
-            Wdl::Loss => Score::mated(ply),
+            Wdl::Win => Score::winning(ply),
+            Wdl::Loss => Score::losing(ply),
             _ => Score::new(0),
         }
     }


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 4.40 +/- 3.91, nElo: 7.61 +/- 6.75
LOS: 98.64 %, DrawRatio: 48.01 %, PairsRatio: 1.08
Games: 10176, Wins: 2740, Losses: 2611, Draws: 4825, Points: 5152.5 (50.63 %)
Ptnml(0-2): [115, 1156, 2443, 1233, 141], WL/DD Ratio: 1.01
LLR: 2.90 (100.4%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```