### PR TITLE
Remove unnecessary cache for syzygy wdl probing

### DIFF
--- a/lib/syzygy/tablebase.rs
+++ b/lib/syzygy/tablebase.rs
@@ -1,6 +1,6 @@
 use crate::chess::{Castles, MovePack, MoveSet, Position};
 use crate::syzygy::{Dtz, DtzTable, Material, NormalizedMaterial, TableDescriptor, Wdl, WdlTable};
-use crate::util::{Integer, Memory};
+use crate::util::Integer;
 use derive_more::with_trait::Debug;
 use rustc_hash::FxHashMap;
 use std::{collections::hash_map::Entry, ffi::OsStr, io, path::Path, str::FromStr};
@@ -140,19 +140,12 @@ impl Tablebase {
     }
 
     fn get_wdl(&self, pos: &Position) -> Option<Wdl> {
-        #[ctor::ctor]
-        static CACHE: Memory<Wdl, u32> = { Memory::new(1 << 22) };
-
         if pos.occupied().len() == 2 {
             Some(Wdl::Draw)
-        } else if let Some(wdl) = CACHE.get(pos.zobrists().hash) {
-            Some(wdl)
         } else {
             let material = Material::from_iter(pos.iter().map(|(p, _)| p));
             let key = material.normalize();
-            let wdl = self.wdl.get(&key)?.probe(pos, material);
-            CACHE.set(pos.zobrists().hash, wdl);
-            Some(wdl)
+            Some(self.wdl.get(&key)?.probe(pos, material))
         }
     }
 

--- a/lib/syzygy/wdl.rs
+++ b/lib/syzygy/wdl.rs
@@ -1,6 +1,5 @@
 use crate::search::{Ply, Score};
-use crate::syzygy::Dtz;
-use crate::util::{Binary, Bits, Integer};
+use crate::{syzygy::Dtz, util::Integer};
 use std::ops::Neg;
 
 /// The possible outcomes of a final [`Position`].
@@ -69,20 +68,6 @@ impl From<Dtz> for Wdl {
     }
 }
 
-impl Binary for Wdl {
-    type Bits = Bits<u8, 3>;
-
-    #[inline(always)]
-    fn encode(&self) -> Self::Bits {
-        Bits::new((self.get() - Self::MIN + 1).cast())
-    }
-
-    #[inline(always)]
-    fn decode(bits: Self::Bits) -> Self {
-        Wdl::new(bits.cast::<i8>() + Self::MIN - 1)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,15 +76,5 @@ mod tests {
     #[proptest]
     fn wdl_has_an_equivalent_dtz(wdl: Wdl) {
         assert_eq!(Wdl::from(Dtz::from(wdl)), wdl);
-    }
-
-    #[proptest]
-    fn decoding_encoded_wdl_is_an_identity(wdl: Wdl) {
-        assert_eq!(Wdl::decode(wdl.encode()), wdl);
-    }
-
-    #[proptest]
-    fn decoding_encoded_optional_wdl_is_an_identity(wdl: Option<Wdl>) {
-        assert_eq!(Option::decode(wdl.encode()), wdl);
     }
 }


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 24 -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 1.07 +/- 2.26, nElo: 1.83 +/- 3.87
LOS: 82.29 %, DrawRatio: 47.94 %, PairsRatio: 1.02
Games: 30942, Wins: 8267, Losses: 8172, Draws: 14503, Points: 15518.5 (50.15 %)
Ptnml(0-2): [405, 3580, 7417, 3653, 416], WL/DD Ratio: 1.04
LLR: 2.90 (100.4%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```