### PR TITLE
Cache last seen accumulators per king bucket

### DIFF
--- a/lib/chess/board.rs
+++ b/lib/chess/board.rs
@@ -1,5 +1,6 @@
 use crate::chess::*;
 use crate::util::{Assume, Integer};
+use bytemuck::Zeroable;
 use derive_more::with_trait::{Debug, Display, Error};
 use std::fmt::{self, Formatter, Write};
 use std::io::Write as _;
@@ -8,7 +9,7 @@ use std::str::{self, FromStr};
 #[cfg(test)]
 use proptest::strategy::LazyJust;
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Zeroable)]
 pub struct Zobrists {
     pub hash: Zobrist,
     pub pawns: Zobrist,
@@ -44,7 +45,7 @@ impl Zobrists {
 }
 
 /// The chess board.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[debug("Board({self})")]
 pub struct Board {
@@ -119,6 +120,24 @@ impl Default for Board {
 }
 
 impl Board {
+    /// The [`Color`] bitboards.
+    #[inline(always)]
+    pub fn colors(&self) -> [Bitboard; 2] {
+        self.colors
+    }
+
+    /// The [`Role`] bitboards.
+    #[inline(always)]
+    pub fn roles(&self) -> [Bitboard; 6] {
+        self.roles
+    }
+
+    /// The [`Piece`]s table.
+    #[inline(always)]
+    pub fn pieces(&self) -> [Option<Piece>; 64] {
+        self.pieces
+    }
+
     /// [`Square`]s occupied by [`Piece`]s of a [`Color`].
     #[inline(always)]
     pub fn material(&self, c: Color) -> Bitboard {

--- a/lib/chess/color.rs
+++ b/lib/chess/color.rs
@@ -1,9 +1,10 @@
 use crate::{chess::Flip, util::Integer};
+use bytemuck::{Zeroable, ZeroableInOption};
 use derive_more::with_trait::Display;
 use std::ops::Not;
 
 /// The color of a chess [`Piece`][`crate::Piece`].
-#[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(u8)]
 pub enum Color {
@@ -12,6 +13,8 @@ pub enum Color {
     #[display("black")]
     Black,
 }
+
+unsafe impl ZeroableInOption for Color {}
 
 unsafe impl Integer for Color {
     type Repr = u8;

--- a/lib/chess/file.rs
+++ b/lib/chess/file.rs
@@ -1,11 +1,12 @@
 use crate::chess::{Bitboard, Mirror, Rank, Transpose};
 use crate::util::{Assume, Integer};
+use bytemuck::{Zeroable, ZeroableInOption};
 use derive_more::with_trait::{Display, Error};
 use std::fmt::{self, Formatter, Write};
 use std::{ops::Sub, str::FromStr};
 
 /// A column on the chess board.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(i8)]
 pub enum File {
@@ -18,6 +19,8 @@ pub enum File {
     G,
     H,
 }
+
+unsafe impl ZeroableInOption for File {}
 
 impl File {
     /// Returns a [`Bitboard`] that only contains this file.

--- a/lib/chess/geometry.rs
+++ b/lib/chess/geometry.rs
@@ -1,4 +1,5 @@
 use crate::{chess::Color, util::Integer};
+use bytemuck::{Zeroable, ZeroableInOption};
 
 /// Trait for types that can be seen from a different perspective.
 pub trait Perspective<T>: Sized {
@@ -23,13 +24,15 @@ impl<T: Flip> Perspective<Color> for T {
 }
 
 /// One of two horizontal perspectives.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(u8)]
 pub enum Side {
     Left,
     Right,
 }
+
+unsafe impl ZeroableInOption for Side {}
 
 unsafe impl Integer for Side {
     type Repr = u8;

--- a/lib/chess/move.rs
+++ b/lib/chess/move.rs
@@ -1,5 +1,6 @@
 use crate::chess::{Bitboard, Flip, Perspective, Piece, Rank, Role, Square, Squares};
 use crate::util::{Assume, Binary, Bits, Integer};
+use bytemuck::ZeroableInOption;
 use std::fmt::{self, Debug, Display, Formatter, Write};
 use std::{num::NonZeroU16, ops::RangeBounds};
 
@@ -107,6 +108,8 @@ impl Display for Move {
         Ok(())
     }
 }
+
+unsafe impl ZeroableInOption for Move {}
 
 impl Binary for Move {
     type Bits = Bits<u16, 16>;

--- a/lib/chess/phase.rs
+++ b/lib/chess/phase.rs
@@ -1,10 +1,11 @@
 use crate::util::Integer;
+use bytemuck::Zeroable;
 
 /// The game phase.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(transparent)]
-pub struct Phase(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as Integer>::Repr);
+pub struct Phase(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Phase as Integer>::Repr);
 
 impl Phase {
     pub const LEN: usize = Phase::MAX as usize + 1;

--- a/lib/chess/piece.rs
+++ b/lib/chess/piece.rs
@@ -1,12 +1,12 @@
 use crate::chess::{Bitboard, Color, Flip, Magic, Perspective, Rank, Role, Square};
 use crate::util::{Assume, Integer};
-use bytemuck::zeroed;
+use bytemuck::{Zeroable, ZeroableInOption, zeroed};
 use derive_more::with_trait::{Display, Error};
 use std::fmt::{self, Formatter, Write};
 use std::{cell::SyncUnsafeCell, ops::Shl, str::FromStr};
 
 /// A chess [piece][`Role`] of a certain [`Color`].
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(u8)]
 pub enum Piece {
@@ -192,6 +192,8 @@ impl Piece {
         }
     }
 }
+
+unsafe impl ZeroableInOption for Piece {}
 
 unsafe impl Integer for Piece {
     type Repr = u8;

--- a/lib/chess/rank.rs
+++ b/lib/chess/rank.rs
@@ -1,11 +1,12 @@
 use crate::chess::{Bitboard, File, Flip, Transpose};
 use crate::util::{Assume, Integer};
+use bytemuck::{Zeroable, ZeroableInOption};
 use derive_more::with_trait::{Display, Error};
 use std::fmt::{self, Formatter, Write};
 use std::{ops::Sub, str::FromStr};
 
 /// A row on the chess board.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(i8)]
 pub enum Rank {
@@ -26,6 +27,8 @@ impl Rank {
         Bitboard::new(0x000000000000FF << (self.get() * 8))
     }
 }
+
+unsafe impl ZeroableInOption for Rank {}
 
 unsafe impl Integer for Rank {
     type Repr = i8;

--- a/lib/chess/role.rs
+++ b/lib/chess/role.rs
@@ -1,10 +1,11 @@
 use crate::util::Integer;
+use bytemuck::{Zeroable, ZeroableInOption};
 use derive_more::with_trait::{Display, Error};
 use std::fmt::{self, Formatter, Write};
 use std::str::FromStr;
 
 /// The type of a chess [`Piece`][`crate::Piece`].
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(u8)]
 pub enum Role {
@@ -15,6 +16,8 @@ pub enum Role {
     Queen,
     King,
 }
+
+unsafe impl ZeroableInOption for Role {}
 
 unsafe impl Integer for Role {
     type Repr = u8;

--- a/lib/chess/square.rs
+++ b/lib/chess/square.rs
@@ -1,12 +1,13 @@
 use crate::chess::*;
 use crate::util::{Assume, Binary, Bits, Integer};
+use bytemuck::{Zeroable, ZeroableInOption};
 use derive_more::with_trait::{Display, Error, From};
 use std::fmt::{self, Formatter};
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::str::FromStr;
 
 /// A square on the chess board.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(i8)]
 #[rustfmt::skip]
@@ -46,6 +47,8 @@ impl Square {
         Bitboard::new(1 << self.get())
     }
 }
+
+unsafe impl ZeroableInOption for Square {}
 
 unsafe impl Integer for Square {
     type Repr = i8;

--- a/lib/nnue/feature.rs
+++ b/lib/nnue/feature.rs
@@ -1,11 +1,12 @@
 use crate::chess::{Color, File, Perspective, Piece, Side, Square};
 use crate::util::Integer;
+use bytemuck::Zeroable;
 
 /// The king's bucket.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(transparent)]
-pub struct Bucket(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as Integer>::Repr);
+pub struct Bucket(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Bucket as Integer>::Repr);
 
 impl Bucket {
     pub const LEN: usize = Self::MAX as usize + 1;
@@ -18,10 +19,10 @@ unsafe impl Integer for Bucket {
 }
 
 /// A bucketed feature set with horizontal mirroring.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(transparent)]
-pub struct Feature(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as Integer>::Repr);
+pub struct Feature(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Feature as Integer>::Repr);
 
 unsafe impl Integer for Feature {
     type Repr = u16;

--- a/lib/nnue/transformer.rs
+++ b/lib/nnue/transformer.rs
@@ -34,11 +34,77 @@ where
         add: [Option<Feature>; 2],
     ) {
         match (sub, add) {
+            ([Some(s1), None], [None, None]) => {
+                let s1 = self.weight.get(s1.cast::<usize>()).assume();
+
+                for i in 0..N {
+                    acc[i] -= s1[i];
+                }
+            }
+
             ([None, None], [Some(a1), None]) => {
                 let a1 = self.weight.get(a1.cast::<usize>()).assume();
 
                 for i in 0..N {
                     acc[i] += a1[i];
+                }
+            }
+
+            ([Some(s1), Some(s2)], [None, None]) => {
+                let s1 = self.weight.get(s1.cast::<usize>()).assume();
+                let s2 = self.weight.get(s2.cast::<usize>()).assume();
+
+                for i in 0..N {
+                    acc[i] -= s1[i] + s2[i];
+                }
+            }
+
+            ([None, None], [Some(a1), Some(a2)]) => {
+                let a1 = self.weight.get(a1.cast::<usize>()).assume();
+                let a2 = self.weight.get(a2.cast::<usize>()).assume();
+
+                for i in 0..N {
+                    acc[i] += a1[i] + a2[i];
+                }
+            }
+
+            ([Some(s1), None], [Some(a1), None]) => {
+                let s1 = self.weight.get(s1.cast::<usize>()).assume();
+                let a1 = self.weight.get(a1.cast::<usize>()).assume();
+
+                for i in 0..N {
+                    acc[i] += a1[i] - s1[i];
+                }
+            }
+
+            ([Some(s1), None], [Some(a1), Some(a2)]) => {
+                let s1 = self.weight.get(s1.cast::<usize>()).assume();
+                let a1 = self.weight.get(a1.cast::<usize>()).assume();
+                let a2 = self.weight.get(a2.cast::<usize>()).assume();
+
+                for i in 0..N {
+                    acc[i] += a1[i] - s1[i] + a2[i];
+                }
+            }
+
+            ([Some(s1), Some(s2)], [Some(a1), None]) => {
+                let s1 = self.weight.get(s1.cast::<usize>()).assume();
+                let s2 = self.weight.get(s2.cast::<usize>()).assume();
+                let a1 = self.weight.get(a1.cast::<usize>()).assume();
+
+                for i in 0..N {
+                    acc[i] += a1[i] - s1[i] - s2[i];
+                }
+            }
+
+            ([Some(s1), Some(s2)], [Some(a1), Some(a2)]) => {
+                let s1 = self.weight.get(s1.cast::<usize>()).assume();
+                let s2 = self.weight.get(s2.cast::<usize>()).assume();
+                let a1 = self.weight.get(a1.cast::<usize>()).assume();
+                let a2 = self.weight.get(a2.cast::<usize>()).assume();
+
+                for i in 0..N {
+                    acc[i] += a1[i] - s1[i] + a2[i] - s2[i];
                 }
             }
 
@@ -141,6 +207,19 @@ mod tests {
     }
 
     #[proptest]
+    fn updates_accumulator_in_place_by_removing_one_feature(
+        t: Affine<i16, 3>,
+        s1: Feature,
+        #[strategy(uniform3(-128..128i16))] prev: [i16; 3],
+    ) {
+        let mut new = prev;
+        t.accumulate_in_place(&mut new, [Some(s1), None], [None, None]);
+
+        let s1 = t.weight[s1.cast::<usize>()];
+        assert_eq!(new, [prev[0] - s1[0], prev[1] - s1[1], prev[2] - s1[2]]);
+    }
+
+    #[proptest]
     fn updates_accumulator_in_place_by_adding_one_feature(
         t: Affine<i16, 3>,
         a1: Feature,
@@ -151,6 +230,151 @@ mod tests {
 
         let a1 = t.weight[a1.cast::<usize>()];
         assert_eq!(new, [prev[0] + a1[0], prev[1] + a1[1], prev[2] + a1[2]]);
+    }
+
+    #[proptest]
+    fn updates_accumulator_in_place_by_removing_two_features(
+        t: Affine<i16, 3>,
+        s1: Feature,
+        s2: Feature,
+        #[strategy(uniform3(-128..128i16))] prev: [i16; 3],
+    ) {
+        let mut new = prev;
+        t.accumulate_in_place(&mut new, [Some(s1), Some(s2)], [None, None]);
+
+        let s1 = t.weight[s1.cast::<usize>()];
+        let s2 = t.weight[s2.cast::<usize>()];
+
+        assert_eq!(
+            new,
+            [
+                prev[0] - s1[0] - s2[0],
+                prev[1] - s1[1] - s2[1],
+                prev[2] - s1[2] - s2[2],
+            ]
+        );
+    }
+
+    #[proptest]
+    fn updates_accumulator_in_place_by_adding_two_features(
+        t: Affine<i16, 3>,
+        a1: Feature,
+        a2: Feature,
+        #[strategy(uniform3(-128..128i16))] prev: [i16; 3],
+    ) {
+        let mut new = prev;
+        t.accumulate_in_place(&mut new, [None, None], [Some(a1), Some(a2)]);
+
+        let a1 = t.weight[a1.cast::<usize>()];
+        let a2 = t.weight[a2.cast::<usize>()];
+        assert_eq!(
+            new,
+            [
+                prev[0] + a1[0] + a2[0],
+                prev[1] + a1[1] + a2[1],
+                prev[2] + a1[2] + a2[2],
+            ]
+        );
+    }
+
+    #[proptest]
+    fn updates_accumulator_in_place_by_adding_one_and_removing_one_features(
+        t: Affine<i16, 3>,
+        a1: Feature,
+        s1: Feature,
+        #[strategy(uniform3(-128..128i16))] prev: [i16; 3],
+    ) {
+        let mut new = prev;
+        t.accumulate_in_place(&mut new, [Some(s1), None], [Some(a1), None]);
+
+        let a1 = t.weight[a1.cast::<usize>()];
+        let s1 = t.weight[s1.cast::<usize>()];
+
+        assert_eq!(
+            new,
+            [
+                prev[0] + a1[0] - s1[0],
+                prev[1] + a1[1] - s1[1],
+                prev[2] + a1[2] - s1[2],
+            ]
+        );
+    }
+
+    #[proptest]
+    fn updates_accumulator_in_place_by_adding_two_and_removing_one_features(
+        t: Affine<i16, 3>,
+        a1: Feature,
+        a2: Feature,
+        s1: Feature,
+        #[strategy(uniform3(-128..128i16))] prev: [i16; 3],
+    ) {
+        let mut new = prev;
+        t.accumulate_in_place(&mut new, [Some(s1), None], [Some(a1), Some(a2)]);
+
+        let a1 = t.weight[a1.cast::<usize>()];
+        let a2 = t.weight[a2.cast::<usize>()];
+        let s1 = t.weight[s1.cast::<usize>()];
+
+        assert_eq!(
+            new,
+            [
+                prev[0] + a1[0] - s1[0] + a2[0],
+                prev[1] + a1[1] - s1[1] + a2[1],
+                prev[2] + a1[2] - s1[2] + a2[2],
+            ]
+        );
+    }
+
+    #[proptest]
+    fn updates_accumulator_in_place_by_adding_one_and_removing_two_features(
+        t: Affine<i16, 3>,
+        a1: Feature,
+        s1: Feature,
+        s2: Feature,
+        #[strategy(uniform3(-128..128i16))] prev: [i16; 3],
+    ) {
+        let mut new = prev;
+        t.accumulate_in_place(&mut new, [Some(s1), Some(s2)], [Some(a1), None]);
+
+        let a1 = t.weight[a1.cast::<usize>()];
+        let s1 = t.weight[s1.cast::<usize>()];
+        let s2 = t.weight[s2.cast::<usize>()];
+
+        assert_eq!(
+            new,
+            [
+                prev[0] + a1[0] - s1[0] - s2[0],
+                prev[1] + a1[1] - s1[1] - s2[1],
+                prev[2] + a1[2] - s1[2] - s2[2],
+            ]
+        );
+    }
+
+    #[proptest]
+    fn updates_accumulator_in_place_by_adding_two_and_removing_two_features(
+        t: Affine<i16, 3>,
+        a1: Feature,
+        a2: Feature,
+        s1: Feature,
+        s2: Feature,
+        #[strategy(uniform3(-128..128i16))] prev: [i16; 3],
+    ) {
+        let mut new = prev;
+        t.accumulate_in_place(&mut new, [Some(s1), Some(s2)], [Some(a1), Some(a2)]);
+
+        let a1 = t.weight[a1.cast::<usize>()];
+        let a2 = t.weight[a2.cast::<usize>()];
+        let s1 = t.weight[s1.cast::<usize>()];
+        let s2 = t.weight[s2.cast::<usize>()];
+
+        assert_eq!(
+            new,
+            [
+                prev[0] + a1[0] - s1[0] + a2[0] - s2[0],
+                prev[1] + a1[1] - s1[1] + a2[1] - s2[1],
+                prev[2] + a1[2] - s1[2] + a2[2] - s2[2],
+            ]
+        );
     }
 
     #[proptest]

--- a/lib/nnue/value.rs
+++ b/lib/nnue/value.rs
@@ -1,10 +1,13 @@
 use crate::chess::Flip;
 use crate::util::{Bounded, Integer};
+use bytemuck::Zeroable;
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(transparent)]
-pub struct ValueRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as Integer>::Repr);
+pub struct ValueRepr(
+    #[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <ValueRepr as Integer>::Repr,
+);
 
 unsafe impl Integer for ValueRepr {
     type Repr = i16;

--- a/lib/search/depth.rs
+++ b/lib/search/depth.rs
@@ -1,9 +1,12 @@
 use crate::util::{Assume, Binary, Bits, Bounded, Integer};
+use bytemuck::Zeroable;
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(transparent)]
-pub struct DepthRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as Integer>::Repr);
+pub struct DepthRepr(
+    #[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <DepthRepr as Integer>::Repr,
+);
 
 unsafe impl Integer for DepthRepr {
     type Repr = i8;

--- a/lib/search/ply.rs
+++ b/lib/search/ply.rs
@@ -1,12 +1,14 @@
 use crate::util::{Bounded, Integer};
+use bytemuck::Zeroable;
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(transparent)]
-pub struct PlyRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as Integer>::Repr);
+pub struct PlyRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <PlyRepr as Integer>::Repr);
 
 unsafe impl Integer for PlyRepr {
     type Repr = i8;
+
     const MIN: Self::Repr = 0;
 
     #[cfg(not(test))]

--- a/lib/search/score.rs
+++ b/lib/search/score.rs
@@ -1,6 +1,7 @@
 use crate::nnue::Value;
 use crate::util::{Binary, Bits, Bounded, Integer};
 use crate::{chess::Flip, search::Ply};
+use bytemuck::Zeroable;
 
 /// Number of [plies][`Ply`] to mate.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
@@ -23,10 +24,10 @@ impl Mate {
     }
 }
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(transparent)]
-pub struct ScoreRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as Integer>::Repr);
+pub struct ScoreRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Score as Integer>::Repr);
 
 unsafe impl Integer for ScoreRepr {
     type Repr = i16;

--- a/lib/search/statistics.rs
+++ b/lib/search/statistics.rs
@@ -134,7 +134,7 @@ impl<const MIN: i16, const MAX: i16> Stat for Graviton<MIN, MAX> {
 
     #[inline(always)]
     fn get(&mut self) -> Self::Value {
-        const { assert!(MIN <= MAX) }
+        const { assert!(MIN <= 0 && 0 <= MAX) }
         self.0
     }
 

--- a/lib/syzygy/dtz.rs
+++ b/lib/syzygy/dtz.rs
@@ -1,11 +1,12 @@
 use crate::syzygy::Wdl;
 use crate::util::{Binary, Bits, Bounded, Integer};
+use bytemuck::Zeroable;
 use derive_more::with_trait::{Constructor, Neg};
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Constructor, Neg)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Constructor, Neg, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(transparent)]
-pub struct DtzRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as Integer>::Repr);
+pub struct DtzRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <DtzRepr as Integer>::Repr);
 
 unsafe impl Integer for DtzRepr {
     type Repr = i16;

--- a/lib/syzygy/wdl.rs
+++ b/lib/syzygy/wdl.rs
@@ -1,9 +1,10 @@
 use crate::search::{Ply, Score};
 use crate::{syzygy::Dtz, util::Integer};
+use bytemuck::{Zeroable, ZeroableInOption};
 use std::ops::Neg;
 
 /// The possible outcomes of a final [`Position`].
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(i8)]
 pub enum Wdl {
@@ -18,6 +19,8 @@ pub enum Wdl {
     /// Unconditional win.
     Win = 2,
 }
+
+unsafe impl ZeroableInOption for Wdl {}
 
 unsafe impl Integer for Wdl {
     type Repr = i8;

--- a/lib/util/bits.rs
+++ b/lib/util/bits.rs
@@ -41,7 +41,7 @@ pub const fn bits<U: Integer<Repr: Unsigned>>(i: u128) -> U {
     unsafe { transmute_copy(&i) }
 }
 
-unsafe impl<T: Unsigned + 'static, const W: u32> NoUninit for Bits<T, W> {}
+unsafe impl<T: NoUninit, const W: u32> NoUninit for Bits<T, W> {}
 
 unsafe impl<T: Unsigned + 'static, const W: u32> Integer for Bits<T, W> {
     type Repr = T;

--- a/lib/util/bounded.rs
+++ b/lib/util/bounded.rs
@@ -1,17 +1,20 @@
 use crate::util::{Integer, Signed};
+use bytemuck::{NoUninit, Zeroable};
 use derive_more::with_trait::{Debug, Display, Error};
 use std::fmt::{self, Formatter};
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use std::{cmp::Ordering, mem::size_of, num::Saturating as S, str::FromStr};
 
 /// A saturating bounded integer.
-#[derive(Debug, Default, Copy, Clone, Hash)]
+#[derive(Debug, Default, Copy, Clone, Hash, Zeroable)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[cfg_attr(test, arbitrary(bound(T, Self: Debug)))]
 #[debug("Bounded({self})")]
 #[debug(bounds(T: Integer<Repr: Signed>, T::Repr: Display))]
 #[repr(transparent)]
 pub struct Bounded<T>(T);
+
+unsafe impl<T: NoUninit> NoUninit for Bounded<T> {}
 
 unsafe impl<T: Integer<Repr: Signed>> Integer for Bounded<T> {
     type Repr = T::Repr;


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 9.94 +/- 4.45, nElo: 18.21 +/- 8.14
LOS: 100.00 %, DrawRatio: 49.70 %, PairsRatio: 1.23
Games: 6990, Wins: 1844, Losses: 1644, Draws: 3502, Points: 3595.0 (51.43 %)
Ptnml(0-2): [45, 745, 1737, 901, 67], WL/DD Ratio: 0.87
LLR: 2.90 (100.2%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```