### PR TITLE
Update NNUE architecture to 768x12hm -> 1536x2 -> 1x8

### DIFF
--- a/bin/trainer.rs
+++ b/bin/trainer.rs
@@ -177,7 +177,7 @@ impl TrainingDataFilter {
         let frequency = count as f64 / total as f64;
 
         // Calculate the acceptance probability for this piece count
-        let acceptance = 0.7 * DESIRED_DISTRIBUTION[pc] / frequency;
+        let acceptance = 0.5 * DESIRED_DISTRIBUTION[pc] / frequency;
         1. - acceptance.clamp(0., 1.)
     }
 
@@ -199,9 +199,8 @@ impl TrainingDataFilter {
 
 const SB0: usize = 200;
 const SB1: usize = 800;
-const EVAL_SCALE: i16 = 508;
 const Q0: i16 = 255;
-const Q1: i16 = 16 * EVAL_SCALE;
+const Q1: i16 = 8128;
 const MAX_WEIGHT: f32 = 127. * 127. / Q1 as f32;
 
 /// An efficiently updatable neural network (NNUE) trainer.
@@ -325,7 +324,7 @@ impl Orchestrator {
             ])
             .use_win_rate_model()
             .loss_fn(|output, pt| {
-                let score = EVAL_SCALE as f32 * output;
+                let score = 300. * output;
                 let q = (score - 270.) / 340.;
                 let qm = (-score - 270.) / 340.;
                 let qf = 0.5 * (1. + q.sigmoid() - qm.sigmoid());

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -206,7 +206,7 @@ impl Evaluator {
         }
 
         let phase = self.phase();
-        let out = Nnue::output(phase);
+        let output = Nnue::output(phase);
 
         let idx = self.ply.cast::<usize>();
         debug_assert_eq!(self.pending[0][idx], None);
@@ -214,7 +214,7 @@ impl Evaluator {
 
         let us = self.turn() as usize;
         let them = self.turn().flip() as usize;
-        let value = out.forward(&self.accumulator[idx][us], &self.accumulator[idx][them]) / 75;
+        let value = output.forward(&self.accumulator[idx][us], &self.accumulator[idx][them]) / 128;
         value.saturate()
     }
 

--- a/lib/nnue/feature.rs
+++ b/lib/nnue/feature.rs
@@ -15,7 +15,7 @@ impl Bucket {
 unsafe impl Integer for Bucket {
     type Repr = u8;
     const MIN: Self::Repr = 0;
-    const MAX: Self::Repr = 15;
+    const MAX: Self::Repr = 23;
 }
 
 /// A bucketed feature set with horizontal mirroring.
@@ -50,14 +50,14 @@ impl Feature {
     pub fn bucket(side: Color, ksq: Square) -> Bucket {
         #[rustfmt::skip]
         const BUCKETS: [u8; 64] = [
-             8,  8,  9,  9, 1, 1, 0, 0,
-            10, 10, 11, 11, 3, 3, 2, 2,
-            12, 12, 13, 13, 5, 5, 4, 4,
-            12, 12, 13, 13, 5, 5, 4, 4,
-            14, 14, 15, 15, 7, 7, 6, 6,
-            14, 14, 15, 15, 7, 7, 6, 6,
-            14, 14, 15, 15, 7, 7, 6, 6,
-            14, 14, 15, 15, 7, 7, 6, 6,
+            12, 13, 14, 15,  3,  2,  1,  0,
+            16, 17, 18, 19,  7,  6,  5,  4,
+            20, 20, 21, 21,  9,  9,  8,  8,
+            20, 20, 21, 21,  9,  9,  8,  8,
+            22, 22, 23, 23, 11, 11, 10, 10,
+            22, 22, 23, 23, 11, 11, 10, 10,
+            22, 22, 23, 23, 11, 11, 10, 10,
+            22, 22, 23, 23, 11, 11, 10, 10,
         ];
 
         Integer::new(BUCKETS[ksq.perspective(side).cast::<usize>()])


### PR DESCRIPTION
## SPRT


> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/UHO_Lichess_4852_v1.epd order=random -tb /tmp/syzygy/ -concurrency 12 -use-affinity -recover -engine name=dev cmd=engines/dev -engine name=base cmd=engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 6.96 +/- 3.76, nElo: 11.90 +/- 6.42
LOS: 99.99 %, DrawRatio: 45.85 %, PairsRatio: 1.15
Games: 11236, Wins: 3050, Losses: 2825, Draws: 5361, Points: 5730.5 (51.00 %)
Ptnml(0-2): [131, 1281, 2576, 1492, 138], WL/DD Ratio: 0.99
LLR: 2.90 (100.2%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```