### PR TITLE
Reimplement inference in terms of portable_simd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,11 +15,11 @@ jobs:
       with:
         lfs: true
     - run: cargo install --force cargo-pgo
-    - run: make cinder-linux-x86-64 cinder-linux-x86-64-v2 cinder-linux-x86-64-v3
+    - run: make linux-x86-64-sse4 linux-x86-64-avx2
       if: runner.os == 'Linux'
-    - run: make cinder-windows-x86-64 cinder-windows-x86-64-v2 cinder-windows-x86-64-v3
+    - run: make windows-x86-64-sse4 windows-x86-64-avx2
       if: runner.os == 'Windows'
-    - run: make cinder-mac-apple-m1 cinder-mac-apple-m2 cinder-mac-apple-m3 cinder-mac-apple-m4
+    - run: make mac-aarch64-neon mac-aarch64-sme
       if: runner.os == 'macOS'
     - run: ls "${{ github.workspace }}/target/bin/"
     - uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,9 @@ jobs:
       with:
         lfs: true
     - run: cargo install --force cargo-pgo
-    - run: make cinder-linux-x86-64 cinder-linux-x86-64-v2 cinder-linux-x86-64-v3
+    - run: make linux-x86-64-sse4 linux-x86-64-avx2
       if: runner.os == 'Linux'
-    - run: make cinder-windows-x86-64 cinder-windows-x86-64-v2 cinder-windows-x86-64-v3
+    - run: make windows-x86-64-sse4 windows-x86-64-avx2
       if: runner.os == 'Windows'
-    - run: make cinder-mac-apple-m1 cinder-mac-apple-m2 cinder-mac-apple-m3 cinder-mac-apple-m4
+    - run: make mac-aarch64-neon mac-aarch64-sme
       if: runner.os == 'macOS'

--- a/Makefile
+++ b/Makefile
@@ -16,137 +16,129 @@ else
 	endif
 endif
 
-default: cinder-native
+default: native
 
 spsa:
-	$(call build,$(shell rustc --print host-tuple),native,--features spsa)
+	$(call build,native,$(shell rustc --print host-tuple),native,--features spsa)
 
-cinder-native:
-	$(call build,$(shell rustc --print host-tuple),native,)
+native:
+	$(call build,native,$(shell rustc --print host-tuple),native,)
 
-cinder-linux-x86-64:
-	$(call build,x86_64-unknown-linux-gnu,x86-64,)
+linux-x86-64-sse4:
+	$(call build,sse4,x86_64-unknown-linux-gnu,x86-64-v2,)
 
-cinder-linux-x86-64-v2:
-	$(call build,x86_64-unknown-linux-gnu,x86-64-v2,)
+linux-x86-64-avx2:
+	$(call build,avx2,x86_64-unknown-linux-gnu,x86-64-v3,)
 
-cinder-linux-x86-64-v3:
-	$(call build,x86_64-unknown-linux-gnu,x86-64-v3,)
+linux-x86-64-avx512:
+	$(call build,avx512,x86_64-unknown-linux-gnu,x86-64-v4,)
 
-cinder-linux-x86-64-v4:
-	$(call build,x86_64-unknown-linux-gnu,x86-64-v4,)
+linux-x86-64-vnni512:
+	$(call build,vnni512,x86_64-unknown-linux-gnu,znver5,) # placeholder for x86-64-v5
 
-cinder-windows-x86-64:
-	$(call build,x86_64-pc-windows-msvc,x86-64,)
+windows-x86-64-sse4:
+	$(call build,sse4,x86_64-pc-windows-msvc,x86-64-v2,)
 
-cinder-windows-x86-64-v2:
-	$(call build,x86_64-pc-windows-msvc,x86-64-v2,)
+windows-x86-64-avx2:
+	$(call build,avx2,x86_64-pc-windows-msvc,x86-64-v3,)
 
-cinder-windows-x86-64-v3:
-	$(call build,x86_64-pc-windows-msvc,x86-64-v3,)
+windows-x86-64-avx512:
+	$(call build,avx512,x86_64-pc-windows-msvc,x86-64-v4,)
 
-cinder-windows-x86-64-v4:
-	$(call build,x86_64-pc-windows-msvc,x86-64-v4,)
+windows-x86-64-vnni512:
+	$(call build,vnni512,x86_64-pc-windows-msvc,znver5,) # placeholder for x86-64-v5
 
-cinder-mac-apple-m1:
-	$(call build,aarch64-apple-darwin,apple-m1,)
+mac-aarch64-neon:
+	$(call build,neon,aarch64-apple-darwin,apple-m1,)
 
-cinder-mac-apple-m2:
-	$(call build,aarch64-apple-darwin,apple-m2,)
+mac-aarch64-sme:
+	$(call build,sme,aarch64-apple-darwin,apple-m4,)
 
-cinder-mac-apple-m3:
-	$(call build,aarch64-apple-darwin,apple-m3,)
-
-cinder-mac-apple-m4:
-	$(call build,aarch64-apple-darwin,apple-m4,)
-
-.PHONY: default spsa cinder-native
-.PHONY: cinder-linux-x86-64 cinder-linux-x86-64-v2 cinder-linux-x86-64-v3 cinder-linux-x86-64-v4
-.PHONY: cinder-windows-x86-64 cinder-windows-x86-64-v2 cinder-windows-x86-64-v3 cinder-windows-x86-64-v4
-.PHONY: cinder-mac-apple-m1 cinder-mac-apple-m2 cinder-mac-apple-m3 cinder-mac-apple-m4
+.PHONY: default spsa native
+.PHONY: linux-x86-64-sse4 linux-x86-64-avx2 linux-x86-64-avx512 linux-x86-64-vnni512
+.PHONY: windows-x86-64-sse4 windows-x86-64-avx2 windows-x86-64-avx512 windows-x86-64-vnni512
+.PHONY: mac-aarch64-neon mac-aarch64-sme
 
 define build
-	@echo "Building target $1 for CPU architecture $2"
-	$(call instrument,$1,$2,$3);
+	@echo "Building target $1"
+	$(call instrument,$1,$2,$3,$4);
 	$(call profile,$1,$2);
-	$(call optimize,$1,$2,$3);
+	$(call optimize,$1,$2,$3,$4);
 	$(call release,$1,$2);
 endef
 
 define release
 	@mkdir -p $(BIN_DIR)
-	@cp $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX) $(BIN_DIR)/cinder-v$(CRATE_VERSION)-$(PLATFORM)-$2$(POSTFIX)
+	@cp $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX) $(BIN_DIR)/cinder-v$(CRATE_VERSION)-$(PLATFORM)-$1$(POSTFIX)
 endef
 
 define instrument
 	cargo pgo instrument build -- \
 		--bin=cinder \
 		-Zunstable-options \
-		--config=profile.release.rustflags='["-Ctarget-cpu=$2"]' \
-		-Zbuild-std=core,alloc,std,panic_abort \
-		--target-dir=$(TARGET_DIR)/$2/ \
-		--target=$1 $3
+		--config=profile.release.rustflags='["-Ctarget-cpu=$3"]' \
+		--target-dir=$(TARGET_DIR)/$1/ \
+		--target=$2 $4
 endef
 
 define optimize
 	cargo pgo optimize build -- \
 		--bin=cinder \
 		-Zunstable-options \
-		--config=profile.release.rustflags='["-Ctarget-cpu=$2"]' \
-		-Zbuild-std=core,alloc,std,panic_abort \
-		--target-dir=$(TARGET_DIR)/$2/ \
-		--target=$1 $3
+		--config=profile.release.rustflags='["-Ctarget-cpu=$3"]' \
+		--target-dir=$(TARGET_DIR)/$1/ \
+		--target=$2 $4
 endef
 
 define profile
-	printf "position fen r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 4rrk1/2p1b1p1/p1p3q1/4p3/2P2n1p/1P1NR2P/PB3PP1/3R1QK1 b - - 2 24\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r3qbrk/6p1/2b2pPp/p3pP1Q/PpPpP2P/3P1B2/2PB3K/R5R1 w - - 16 42\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 6k1/1R3p2/6p1/2Bp3p/3P2q1/P7/1P2rQ1K/5R2 b - - 4 44\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/8/1p2k1p1/3p3p/1p1P1P1P/1P2PK2/8/8 w - - 3 54\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 7r/2p3k1/1p1p1qp1/1P1Bp3/p1P2r1P/P7/4R3/Q4RK1 w - - 0 36\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r1bq1rk1/pp2b1pp/n1pp1n2/3P1p2/2P1p3/2N1P2N/PP2BPPP/R1BQ1RK1 b - - 2 10\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 3r3k/2r4p/1p1b3q/p4P2/P2Pp3/1B2P3/3BQ1RP/6K1 w - - 3 87\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 2r4r/1p4k1/1Pnp4/3Qb1pq/8/4BpPp/5P2/2RR1BK1 w - - 0 42\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 4q1bk/6b1/7p/p1p4p/PNPpP2P/KN4P1/3Q4/4R3 b - - 0 37\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 2q3r1/1r2pk2/pp3pp1/2pP3p/P1Pb1BbP/1P4Q1/R3NPP1/4R1K1 w - - 2 34\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 1r2r2k/1b4q1/pp5p/2pPp1p1/P3Pn2/1P1B1Q1P/2R3P1/4BR1K b - - 1 37\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r3kbbr/pp1n1p1P/3ppnp1/q5N1/1P1pP3/P1N1B3/2P1QP2/R3KB1R b KQkq b3 0 17\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/6pk/2b1Rp2/3r4/1R1B2PP/P5K1/8/2r5 b - - 16 42\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 1r4k1/4ppb1/2n1b1qp/pB4p1/1n1BP1P1/7P/2PNQPK1/3RN3 w - - 8 29\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/p2B4/PkP5/4p1pK/4Pb1p/5P2/8/8 w - - 29 68\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 3r4/ppq1ppkp/4bnp1/2pN4/2P1P3/1P4P1/PQ3PBP/R4K2 b - - 2 20\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 5rr1/4n2k/4q2P/P1P2n2/3B1p2/4pP2/2N1P3/1RR1K2Q w - - 1 49\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 1r5k/2pq2p1/3p3p/p1pP4/4QP2/PP1R3P/6PK/8 w - - 1 51\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen q5k1/5ppp/1r3bn1/1B6/P1N2P2/BQ2P1P1/5K1P/8 b - - 2 34\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r1b2k1r/5n2/p4q2/1ppn1Pp1/3pp1p1/NP2P3/P1PPBK2/1RQN2R1 w - - 0 22\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r1bqk2r/pppp1ppp/5n2/4b3/4P3/P1N5/1PP2PPP/R1BQKB1R w KQkq - 0 5\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r1bqr1k1/pp1p1ppp/2p5/8/3N1Q2/P2BB3/1PP2PPP/R3K2n b Q - 1 12\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r1bq2k1/p4r1p/1pp2pp1/3p4/1P1B3Q/P2B1N2/2P3PP/4R1K1 b - - 2 19\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r4qk1/6r1/1p4p1/2ppBbN1/1p5Q/P7/2P3PP/5RK1 w - - 2 25\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r7/6k1/1p6/2pp1p2/7Q/8/p1P2K1P/8 w - - 0 32\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r3k2r/ppp1pp1p/2nqb1pn/3p4/4P3/2PP4/PP1NBPPP/R2QK1NR w KQkq - 1 5\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 3r1rk1/1pp1pn1p/p1n1q1p1/3p4/Q3P3/2P5/PP1NBPPP/4RRK1 w - - 0 12\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 5rk1/1pp1pn1p/p3Brp1/8/1n6/5N2/PP3PPP/2R2RK1 w - - 2 20\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/1p2pk1p/p1p1r1p1/3n4/8/5R2/PP3PPP/4R1K1 b - - 3 27\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/4pk2/1p1r2p1/p1p4p/Pn5P/3R4/1P3PP1/4RK2 w - - 1 33\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/5k2/1pnrp1p1/p1p4p/P6P/4R1PK/1P3P2/4R3 b - - 1 38\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/8/1p1kp1p1/p1pr1n1p/P6P/1R4P1/1P3PK1/1R6 b - - 15 45\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/8/1p1k2p1/p1prp2p/P2n3P/6P1/1P1R1PK1/4R3 b - - 5 49\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/8/1p4p1/p1p2k1p/P2npP1P/4K1P1/1P6/3R4 w - - 6 54\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/8/1p4p1/p1p2k1p/P2n1P1P/4K1P1/1P6/6R1 b - - 6 59\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/5k2/1p4p1/p1pK3p/P2n1P1P/6P1/1P6/4R3 b - - 14 63\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 8/1R6/1p1K1kp1/p6p/P1p2P1P/6P1/1Pn5/8 w - - 0 67\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 1rb1rn1k/p3q1bp/2p3p1/2p1p3/2P1P2N/PP1RQNP1/1B3P2/4R1K1 b - - 4 23\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 4rrk1/pp1n1pp1/q5p1/P1pP4/2n3P1/7P/1P3PB1/R1BQ1RK1 w - - 3 22\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r2qr1k1/pb1nbppp/1pn1p3/2ppP3/3P4/2PB1NN1/PP3PPP/R1BQR1K1 w - - 4 12\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 2r2k2/8/4P1R1/1p6/8/P4K1N/7b/2B5 b - - 0 55\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 6k1/5pp1/8/2bKP2P/2P5/p4PNb/B7/8 b - - 1 44\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 2rqr1k1/1p3p1p/p2p2p1/P1nPb3/2B1P3/5P2/1PQ2NPP/R1R4K w - - 3 25\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen r1b2rk1/p1q1ppbp/6p1/2Q5/8/4BP2/PPP3PP/2KR1B1R b - - 2 14\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 6r1/5k2/p1b1r2p/1pB1p1p1/1Pp3PP/2P1R1K1/2P2P2/3R4 w - - 1 36\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen rnbqkb1r/pppppppp/5n2/8/2PP4/8/PP2PPPP/RNBQKBNR b KQkq c3 0 2\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 2rr2k1/1p4bp/p1q1p1p1/4Pp1n/2PB4/1PN3P1/P3Q2P/2RR2K1 w - f6 0 20\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 3br1k1/p1pn3p/1p3n2/5pNq/2P1p3/1PN3PP/P2Q1PB1/4R1K1 w - - 0 23\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
-	printf "position fen 2r2b2/5p2/5k2/p1r1pP2/P2pB3/1P3P2/K1P3R1/7R w - - 23 93\ngo depth 16" | $(TARGET_DIR)/$2/$1/release/cinder$(POSTFIX)
+	printf "position fen r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 4rrk1/2p1b1p1/p1p3q1/4p3/2P2n1p/1P1NR2P/PB3PP1/3R1QK1 b - - 2 24\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r3qbrk/6p1/2b2pPp/p3pP1Q/PpPpP2P/3P1B2/2PB3K/R5R1 w - - 16 42\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 6k1/1R3p2/6p1/2Bp3p/3P2q1/P7/1P2rQ1K/5R2 b - - 4 44\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/8/1p2k1p1/3p3p/1p1P1P1P/1P2PK2/8/8 w - - 3 54\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 7r/2p3k1/1p1p1qp1/1P1Bp3/p1P2r1P/P7/4R3/Q4RK1 w - - 0 36\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r1bq1rk1/pp2b1pp/n1pp1n2/3P1p2/2P1p3/2N1P2N/PP2BPPP/R1BQ1RK1 b - - 2 10\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 3r3k/2r4p/1p1b3q/p4P2/P2Pp3/1B2P3/3BQ1RP/6K1 w - - 3 87\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 2r4r/1p4k1/1Pnp4/3Qb1pq/8/4BpPp/5P2/2RR1BK1 w - - 0 42\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 4q1bk/6b1/7p/p1p4p/PNPpP2P/KN4P1/3Q4/4R3 b - - 0 37\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 2q3r1/1r2pk2/pp3pp1/2pP3p/P1Pb1BbP/1P4Q1/R3NPP1/4R1K1 w - - 2 34\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 1r2r2k/1b4q1/pp5p/2pPp1p1/P3Pn2/1P1B1Q1P/2R3P1/4BR1K b - - 1 37\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r3kbbr/pp1n1p1P/3ppnp1/q5N1/1P1pP3/P1N1B3/2P1QP2/R3KB1R b KQkq b3 0 17\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/6pk/2b1Rp2/3r4/1R1B2PP/P5K1/8/2r5 b - - 16 42\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 1r4k1/4ppb1/2n1b1qp/pB4p1/1n1BP1P1/7P/2PNQPK1/3RN3 w - - 8 29\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/p2B4/PkP5/4p1pK/4Pb1p/5P2/8/8 w - - 29 68\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 3r4/ppq1ppkp/4bnp1/2pN4/2P1P3/1P4P1/PQ3PBP/R4K2 b - - 2 20\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 5rr1/4n2k/4q2P/P1P2n2/3B1p2/4pP2/2N1P3/1RR1K2Q w - - 1 49\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 1r5k/2pq2p1/3p3p/p1pP4/4QP2/PP1R3P/6PK/8 w - - 1 51\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen q5k1/5ppp/1r3bn1/1B6/P1N2P2/BQ2P1P1/5K1P/8 b - - 2 34\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r1b2k1r/5n2/p4q2/1ppn1Pp1/3pp1p1/NP2P3/P1PPBK2/1RQN2R1 w - - 0 22\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r1bqk2r/pppp1ppp/5n2/4b3/4P3/P1N5/1PP2PPP/R1BQKB1R w KQkq - 0 5\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r1bqr1k1/pp1p1ppp/2p5/8/3N1Q2/P2BB3/1PP2PPP/R3K2n b Q - 1 12\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r1bq2k1/p4r1p/1pp2pp1/3p4/1P1B3Q/P2B1N2/2P3PP/4R1K1 b - - 2 19\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r4qk1/6r1/1p4p1/2ppBbN1/1p5Q/P7/2P3PP/5RK1 w - - 2 25\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r7/6k1/1p6/2pp1p2/7Q/8/p1P2K1P/8 w - - 0 32\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r3k2r/ppp1pp1p/2nqb1pn/3p4/4P3/2PP4/PP1NBPPP/R2QK1NR w KQkq - 1 5\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 3r1rk1/1pp1pn1p/p1n1q1p1/3p4/Q3P3/2P5/PP1NBPPP/4RRK1 w - - 0 12\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 5rk1/1pp1pn1p/p3Brp1/8/1n6/5N2/PP3PPP/2R2RK1 w - - 2 20\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/1p2pk1p/p1p1r1p1/3n4/8/5R2/PP3PPP/4R1K1 b - - 3 27\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/4pk2/1p1r2p1/p1p4p/Pn5P/3R4/1P3PP1/4RK2 w - - 1 33\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/5k2/1pnrp1p1/p1p4p/P6P/4R1PK/1P3P2/4R3 b - - 1 38\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/8/1p1kp1p1/p1pr1n1p/P6P/1R4P1/1P3PK1/1R6 b - - 15 45\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/8/1p1k2p1/p1prp2p/P2n3P/6P1/1P1R1PK1/4R3 b - - 5 49\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/8/1p4p1/p1p2k1p/P2npP1P/4K1P1/1P6/3R4 w - - 6 54\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/8/1p4p1/p1p2k1p/P2n1P1P/4K1P1/1P6/6R1 b - - 6 59\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/5k2/1p4p1/p1pK3p/P2n1P1P/6P1/1P6/4R3 b - - 14 63\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 8/1R6/1p1K1kp1/p6p/P1p2P1P/6P1/1Pn5/8 w - - 0 67\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 1rb1rn1k/p3q1bp/2p3p1/2p1p3/2P1P2N/PP1RQNP1/1B3P2/4R1K1 b - - 4 23\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 4rrk1/pp1n1pp1/q5p1/P1pP4/2n3P1/7P/1P3PB1/R1BQ1RK1 w - - 3 22\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r2qr1k1/pb1nbppp/1pn1p3/2ppP3/3P4/2PB1NN1/PP3PPP/R1BQR1K1 w - - 4 12\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 2r2k2/8/4P1R1/1p6/8/P4K1N/7b/2B5 b - - 0 55\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 6k1/5pp1/8/2bKP2P/2P5/p4PNb/B7/8 b - - 1 44\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 2rqr1k1/1p3p1p/p2p2p1/P1nPb3/2B1P3/5P2/1PQ2NPP/R1R4K w - - 3 25\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen r1b2rk1/p1q1ppbp/6p1/2Q5/8/4BP2/PPP3PP/2KR1B1R b - - 2 14\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 6r1/5k2/p1b1r2p/1pB1p1p1/1Pp3PP/2P1R1K1/2P2P2/3R4 w - - 1 36\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen rnbqkb1r/pppppppp/5n2/8/2PP4/8/PP2PPPP/RNBQKBNR b KQkq c3 0 2\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 2rr2k1/1p4bp/p1q1p1p1/4Pp1n/2PB4/1PN3P1/P3Q2P/2RR2K1 w - f6 0 20\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 3br1k1/p1pn3p/1p3n2/5pNq/2P1p3/1PN3PP/P2Q1PB1/4R1K1 w - - 0 23\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
+	printf "position fen 2r2b2/5p2/5k2/p1r1pP2/P2pB3/1P3P2/K1P3R1/7R w - - 23 93\ngo depth 16" | $(TARGET_DIR)/$1/$2/release/cinder$(POSTFIX)
 endef

--- a/README.md
+++ b/README.md
@@ -9,34 +9,58 @@
 
 Cinder is a hobby chess engine written in Rust.
 
-## Usage
+## Getting started
+
+### Prebuilt binaries
+
+Prebuilt binaries for various popular platforms and CPU architectures are available on
+the [releases] page.
+
+#### Which binary to download?
+
+Use the tables below as a reference for which binary to pick.
+The table is ordered from most compatible to most performant.
+You should prefer the most performant binary that runs on your machine.
+
+| Suffix    | Description                                                      |
+|-----------|------------------------------------------------------------------|
+| `sse4`    | Compatible with most Intel and AMD CPUs                          |
+| `avx2`    | Compatible with Intel Haswell (2013+) and AMD Excavator (2015+)  |
+| `avx512`  | Compatible with Intel Skylake-X (2017+) and AMD Zen 4 (2022+)    |
+| `vnni512` | Compatible with Intel Cascade Lake (2019+) and AMD Zen 4 (2022+) |
+| `neon`    | Apple Silicon M1/M2/M3                                           |
+| `sme`     | Apple Silicon M4+                                                |
+
+### Building from source
+
+Building Cinder from source currently requires a recent nightly Rust compiler, and [cargo-pgo].
+
+#### Installing the latest nightly Rust toolchain
+
+```sh
+rustup toolchain install nightly
+rustup component add llvm-tools-preview
+```
+
+#### Installing `cargo-pgo`
+
+```sh
+cargo install cargo-pgo
+```
+
+#### Building Cinder optimized for your CPU architecture
+
+```sh
+make
+```
+
+You will find the compiled binary under `target/bin/`.
+
+### Usage
 
 Cinder implements the UCI protocol and should be compatible with most chess graphical user
 interfaces (GUI). Users who are familiar with the UCI protocol may also interact with Cinder
 directly on a terminal via its command line interface (CLI).
-
-### Example
-
-```rust
-uci
-id name Cinder 0.3.1
-id author Bruno Dutra
-option name Hash type spin default 16 min 0 max 33554432
-option name Threads type spin default 1 min 1 max 4096
-option name SyzygyPath type string default <empty>
-uciok
-go depth 8
-info depth 0 time 0 nodes 0 nps 0 score cp 14 pv a2a3
-info depth 1 time 0 nodes 0 nps 0 score cp 1 pv b2b3
-info depth 2 time 0 nodes 0 nps 0 score cp 12 pv c2c4
-info depth 3 time 0 nodes 0 nps 0 score cp 20 pv d2d4 c7c6
-info depth 4 time 0 nodes 0 nps 0 score cp 16 pv e2e4 e7e5
-info depth 5 time 0 nodes 0 nps 0 score cp 19 pv d2d4 d7d5 c2c4 d5c4
-info depth 6 time 0 nodes 0 nps 0 score cp 15 pv d2d4 d7d5 c2c4 d5c4 g1f3
-info depth 7 time 1 nodes 0 nps 0 score cp 30 pv e2e4 d7d5 e4d5 d8d5
-info depth 8 time 1 nodes 2048 nps 1250985 score cp 21 pv d2d4 d7d5 c2c4 c7c6 b1c3 g8f6 g1f3
-bestmove d2d4
-```
 
 ## Acknowledgement
 
@@ -52,16 +76,13 @@ Cinder's implementation of the Syzygy tablebases probing algorithm is based on a
 Cinder is an open source project and you're very welcome to contribute to this project by
 opening [issues] and/or [pull requests][pulls], see [CONTRIBUTING] for general guidelines.
 
-Building Cinder from source currently requires a recent nightly Rust compiler,
-and [cargo-pgo]. To compile binaries optimized for your CPU architecture,
-simply run `make`. You will find the compiled binary under `target/bin/`.
-
 ## License
 
 Cinder is distributed under the terms of the GPL-3.0 license, see [LICENSE] for details.
 
 [issues]:                   https://github.com/brunocodutra/cinder/issues
 [pulls]:                    https://github.com/brunocodutra/cinder/pulls
+[releases]:                 https://github.com/brunocodutra/cinder/releases/latest
 
 [cargo-pgo]:                https://crates.io/crates/cargo-pgo
 

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -1,13 +1,17 @@
 #![allow(clippy::collapsible_if)]
 #![cfg_attr(test, recursion_limit = "1024")]
 #![cfg_attr(target_arch = "x86_64", feature(stdarch_x86_mm_shuffle))]
-#![cfg_attr(target_arch = "aarch64", feature(stdarch_aarch64_prefetch))]
+#![cfg_attr(
+    target_arch = "aarch64",
+    feature(stdarch_aarch64_prefetch, stdarch_neon_dotprod)
+)]
 #![feature(
     adt_const_params,
     const_index,
     const_trait_impl,
     coverage_attribute,
     gen_blocks,
+    portable_simd,
     ptr_as_ref_unchecked,
     slice_swap_unchecked,
     sync_unsafe_cell
@@ -21,6 +25,8 @@ pub mod nnue;
 pub mod params;
 /// Minimax searching algorithm.
 pub mod search;
+/// Single Instruction, Multiple Data (SIMD) utilities.
+pub mod simd;
 /// Syzygy tablebase probing.
 pub mod syzygy;
 /// UCI protocol.

--- a/lib/nnue.rs
+++ b/lib/nnue.rs
@@ -21,7 +21,7 @@ const NNUE: Nnue = Nnue::new();
 /// An Efficiently Updatable Neural Network.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Zeroable)]
 pub struct Nnue {
-    transformer: Affine<i16, { Accumulator::LEN }>,
+    transformer: Transformer<i16, { Accumulator::LEN }>,
     output: [Output<{ Accumulator::LEN }>; Phase::LEN],
 }
 
@@ -57,7 +57,7 @@ impl Nnue {
     }
 
     #[inline(always)]
-    pub fn transformer() -> &'static Affine<i16, { Accumulator::LEN }> {
+    pub fn transformer() -> &'static Transformer<i16, { Accumulator::LEN }> {
         &NNUE.transformer
     }
 

--- a/lib/nnue/accumulator.rs
+++ b/lib/nnue/accumulator.rs
@@ -1,4 +1,4 @@
-use crate::util::AlignTo64;
+use crate::util::Aligned;
 use bytemuck::{Zeroable, zeroed};
 use derive_more::with_trait::{Debug, Deref, DerefMut};
 
@@ -8,8 +8,8 @@ use derive_more::with_trait::{Debug, Deref, DerefMut};
 #[debug("Accumulator")]
 #[repr(transparent)]
 pub struct Accumulator(
-    #[cfg_attr(test, map(|vs: [i8; Self::LEN]| AlignTo64(vs.map(i16::from))))]
-    AlignTo64<[i16; Accumulator::LEN]>,
+    #[cfg_attr(test, map(|vs: [i8; Self::LEN]| Aligned(vs.map(i16::from))))]
+    Aligned<[i16; Accumulator::LEN]>,
 );
 
 impl Accumulator {

--- a/lib/nnue/output.rs
+++ b/lib/nnue/output.rs
@@ -1,5 +1,7 @@
-use crate::util::AlignTo64;
+use crate::{simd::*, util::Aligned};
 use bytemuck::Zeroable;
+use std::mem::transmute;
+use std::ops::{Mul, Shr};
 
 /// The output layer.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Zeroable)]
@@ -7,296 +9,41 @@ use bytemuck::Zeroable;
 pub struct Output<const N: usize> {
     #[cfg_attr(test, map(|b: i8| i32::from(b)))]
     pub bias: i32,
-    #[cfg_attr(test, map(|vs: [[i8; N]; 2]| AlignTo64(vs.map(|v| v.map(i16::from)))))]
-    pub weight: AlignTo64<[[i16; N]; 2]>,
-}
-
-impl<const N: usize> Output<N> {
-    #[doc(hidden)]
-    #[inline(always)]
-    #[cfg(target_feature = "avx512f")]
-    pub unsafe fn avx512(&self, us: &[i16; N], them: &[i16; N]) -> i32 {
-        const { assert!(N % 256 == 0) }
-
-        use crate::util::Assume;
-        use std::{arch::x86_64::*, mem::transmute};
-
-        #[inline(always)]
-        unsafe fn dot(w: __m512i, x: __m512i, y: __m512i) -> __m512i {
-            unsafe {
-                let x = _mm512_max_epi16(x, _mm512_setzero_si512());
-                let x = _mm512_min_epu16(x, _mm512_set1_epi16(255));
-                let p = _mm512_mullo_epi16(x, w);
-                _mm512_add_epi32(y, _mm512_madd_epi16(x, p))
-            }
-        }
-
-        unsafe {
-            let mut y0 = _mm512_setzero_si512();
-            let mut y1 = _mm512_setzero_si512();
-            let mut y2 = _mm512_setzero_si512();
-            let mut y3 = _mm512_setzero_si512();
-
-            for (w, x) in self.weight.iter().zip([us, them]) {
-                (w.as_ptr() as usize % 64 == 0).assume();
-                (x.as_ptr() as usize % 64 == 0).assume();
-
-                for (w, x) in w.as_chunks::<256>().0.iter().zip(x.as_chunks::<256>().0) {
-                    let w = transmute::<&[i16; 256], &[__m512i; 8]>(w);
-                    let x = transmute::<&[i16; 256], &[__m512i; 8]>(x);
-
-                    y0 = dot(w[0], x[0], y0);
-                    y1 = dot(w[1], x[1], y1);
-                    y2 = dot(w[2], x[2], y2);
-                    y3 = dot(w[3], x[3], y3);
-                    y0 = dot(w[4], x[4], y0);
-                    y1 = dot(w[5], x[5], y1);
-                    y2 = dot(w[6], x[6], y2);
-                    y3 = dot(w[7], x[7], y3);
-                }
-            }
-
-            let y01 = _mm512_add_epi32(y0, y1);
-            let y23 = _mm512_add_epi32(y2, y3);
-            let y = _mm512_add_epi32(y01, y23);
-
-            self.bias + (_mm512_reduce_add_epi32(y) >> 9)
-        }
-    }
-
-    #[doc(hidden)]
-    #[inline(always)]
-    #[cfg(target_feature = "avx2")]
-    pub unsafe fn avx2(&self, us: &[i16; N], them: &[i16; N]) -> i32 {
-        const { assert!(N.is_multiple_of(128)) }
-
-        use crate::util::Assume;
-        use std::{arch::x86_64::*, mem::transmute};
-
-        #[inline(always)]
-        unsafe fn dot(w: __m256i, x: __m256i, y: __m256i) -> __m256i {
-            unsafe {
-                let x = _mm256_max_epi16(x, _mm256_setzero_si256());
-                let x = _mm256_min_epu16(x, _mm256_set1_epi16(255));
-                let p = _mm256_mullo_epi16(x, w);
-                _mm256_add_epi32(y, _mm256_madd_epi16(x, p))
-            }
-        }
-
-        unsafe {
-            let mut y0 = _mm256_setzero_si256();
-            let mut y1 = _mm256_setzero_si256();
-
-            for (w, x) in self.weight.iter().zip([us, them]) {
-                (w.as_ptr() as usize).is_multiple_of(32).assume();
-                (x.as_ptr() as usize).is_multiple_of(32).assume();
-
-                for (w, x) in w.as_chunks::<128>().0.iter().zip(x.as_chunks::<128>().0) {
-                    let w = transmute::<&[i16; 128], &[__m256i; 8]>(w);
-                    let x = transmute::<&[i16; 128], &[__m256i; 8]>(x);
-
-                    y0 = dot(w[0], x[0], y0);
-                    y1 = dot(w[1], x[1], y1);
-                    y0 = dot(w[2], x[2], y0);
-                    y1 = dot(w[3], x[3], y1);
-                    y0 = dot(w[4], x[4], y0);
-                    y1 = dot(w[5], x[5], y1);
-                    y0 = dot(w[6], x[6], y0);
-                    y1 = dot(w[7], x[7], y1);
-                }
-            }
-
-            let y = _mm256_add_epi32(y0, y1);
-
-            // https://stackoverflow.com/a/60109639
-            let r = _mm256_castsi256_si128(y);
-            let s = _mm256_extracti128_si256(y, 1);
-            let r = _mm_add_epi32(r, s);
-            let s = _mm_unpackhi_epi64(r, r);
-            let r = _mm_add_epi32(r, s);
-            let s = _mm_shuffle_epi32(r, _MM_SHUFFLE(2, 3, 0, 1));
-            let r = _mm_add_epi32(r, s);
-            self.bias + (_mm_extract_epi32(r, 0) >> 9)
-        }
-    }
-
-    #[doc(hidden)]
-    #[inline(always)]
-    #[cfg(target_feature = "ssse3")]
-    pub unsafe fn sse(&self, us: &[i16; N], them: &[i16; N]) -> i32 {
-        const { assert!(N.is_multiple_of(64)) }
-
-        use crate::util::Assume;
-        use std::{arch::x86_64::*, mem::transmute};
-
-        #[inline(always)]
-        unsafe fn dot(w: __m128i, x: __m128i, y: __m128i) -> __m128i {
-            unsafe {
-                let x = _mm_max_epi16(x, _mm_setzero_si128());
-                let x = _mm_min_epu16(x, _mm_set1_epi16(255));
-                let p = _mm_mullo_epi16(x, w);
-                _mm_add_epi32(y, _mm_madd_epi16(x, p))
-            }
-        }
-
-        unsafe {
-            let mut y0 = _mm_setzero_si128();
-            let mut y1 = _mm_setzero_si128();
-
-            for (w, x) in self.weight.iter().zip([us, them]) {
-                (w.as_ptr() as usize).is_multiple_of(32).assume();
-                (x.as_ptr() as usize).is_multiple_of(32).assume();
-
-                for (w, x) in w.as_chunks::<64>().0.iter().zip(x.as_chunks::<64>().0) {
-                    let w = transmute::<&[i16; 64], &[__m128i; 8]>(w);
-                    let x = transmute::<&[i16; 64], &[__m128i; 8]>(x);
-
-                    y0 = dot(w[0], x[0], y0);
-                    y1 = dot(w[1], x[1], y1);
-                    y0 = dot(w[2], x[2], y0);
-                    y1 = dot(w[3], x[3], y1);
-                    y0 = dot(w[4], x[4], y0);
-                    y1 = dot(w[5], x[5], y1);
-                    y0 = dot(w[6], x[6], y0);
-                    y1 = dot(w[7], x[7], y1);
-                }
-            }
-
-            let y = _mm_add_epi32(y0, y1);
-
-            // https://stackoverflow.com/a/35270026
-            let r = _mm_shuffle_epi32(y, _MM_SHUFFLE(1, 0, 3, 2));
-            let s = _mm_add_epi32(r, y);
-            let r = _mm_shufflelo_epi16(s, _MM_SHUFFLE(1, 0, 3, 2));
-            let s = _mm_add_epi32(r, s);
-            self.bias + (_mm_cvtsi128_si32(s) >> 9)
-        }
-    }
-
-    #[doc(hidden)]
-    #[inline(always)]
-    #[cfg(target_feature = "neon")]
-    pub unsafe fn neon(&self, us: &[i16; N], them: &[i16; N]) -> i32 {
-        const { assert!(N % 64 == 0) }
-
-        use crate::util::Assume;
-        use std::{arch::aarch64::*, mem::transmute};
-
-        #[inline(always)]
-        unsafe fn dot(w: int16x8_t, x: int16x8_t, y: int32x4_t) -> int32x4_t {
-            unsafe {
-                let x = vmaxq_s16(x, vdupq_n_s16(0));
-                let x = vminq_s16(x, vdupq_n_s16(255));
-                let p = vmulq_s16(x, w);
-                vmlal_high_s16(vmlal_s16(y, vget_low_s16(x), vget_low_s16(p)), x, p)
-            }
-        }
-
-        unsafe {
-            let mut y0 = vdupq_n_s32(0);
-            let mut y1 = vdupq_n_s32(0);
-            let mut y2 = vdupq_n_s32(0);
-            let mut y3 = vdupq_n_s32(0);
-
-            for (w, x) in self.weight.iter().zip([us, them]) {
-                (w.as_ptr() as usize % 32 == 0).assume();
-                (x.as_ptr() as usize % 32 == 0).assume();
-
-                for (w, x) in w.as_chunks::<64>().0.iter().zip(x.as_chunks::<64>().0) {
-                    let w = transmute::<&[i16; 64], &[int16x8_t; 8]>(w);
-                    let x = transmute::<&[i16; 64], &[int16x8_t; 8]>(x);
-
-                    y0 = dot(w[0], x[0], y0);
-                    y1 = dot(w[1], x[1], y1);
-                    y2 = dot(w[2], x[2], y2);
-                    y3 = dot(w[3], x[3], y3);
-                    y0 = dot(w[4], x[4], y0);
-                    y1 = dot(w[5], x[5], y1);
-                    y2 = dot(w[6], x[6], y2);
-                    y3 = dot(w[7], x[7], y3);
-                }
-            }
-
-            let y01 = vaddq_s32(y0, y1);
-            let y23 = vaddq_s32(y2, y3);
-            let y = vaddq_s32(y01, y23);
-            self.bias + (vaddvq_s32(y) >> 9)
-        }
-    }
-
-    #[doc(hidden)]
-    #[inline(always)]
-    pub fn scalar(&self, us: &[i16; N], them: &[i16; N]) -> i32 {
-        let mut y = 0;
-        for (w, x) in self.weight.iter().zip([us, them]) {
-            for (&w, &x) in Iterator::zip(w.iter(), x.iter()) {
-                y += w as i32 * (x as i32).clamp(0, 255).pow(2);
-            }
-        }
-
-        self.bias + (y >> 9)
-    }
+    #[cfg_attr(test, map(|vs: [[i8; N]; 2]| Aligned(vs.map(|v| v.map(i16::from)))))]
+    pub weight: Aligned<[[i16; N]; 2]>,
 }
 
 impl<const N: usize> Output<N> {
     /// Transforms the accumulator.
     #[inline(always)]
-    pub fn forward(&self, us: &AlignTo64<[i16; N]>, them: &AlignTo64<[i16; N]>) -> i32 {
-        #[cfg(target_feature = "avx512f")]
+    pub fn forward(&self, us: &Aligned<[i16; N]>, them: &Aligned<[i16; N]>) -> i32 {
+        const { assert!(N.is_multiple_of(128)) }
+
         unsafe {
-            self.avx512(us, them)
+            #[cfg(any(target_feature = "avx512f", target_feature = "sme"))]
+            const REGISTERS: usize = 4;
+
+            #[cfg(not(any(target_feature = "avx512f", target_feature = "sme")))]
+            const REGISTERS: usize = 2;
+
+            let mut y = [Simd::splat(0); REGISTERS];
+            for (w, x) in self.weight.iter().zip([us, them]) {
+                let w = transmute::<&[[i16; 128]], &[[i16x32; 4]]>(w.as_chunks_unchecked::<128>());
+                let x = transmute::<&[[i16; 128]], &[[i16x32; 4]]>(x.as_chunks_unchecked::<128>());
+
+                for (w, x) in w.iter().zip(x) {
+                    let p0 = x[0].simd_clamp(Simd::splat(0), Simd::splat(255));
+                    let p1 = x[1].simd_clamp(Simd::splat(0), Simd::splat(255));
+                    let p2 = x[2].simd_clamp(Simd::splat(0), Simd::splat(255));
+                    let p3 = x[3].simd_clamp(Simd::splat(0), Simd::splat(255));
+                    y[0 % REGISTERS] = p0.mul(w[0]).mul_add_2x16(p0, y[0 % REGISTERS]);
+                    y[1 % REGISTERS] = p1.mul(w[1]).mul_add_2x16(p1, y[1 % REGISTERS]);
+                    y[2 % REGISTERS] = p2.mul(w[2]).mul_add_2x16(p2, y[2 % REGISTERS]);
+                    y[3 % REGISTERS] = p3.mul(w[3]).mul_add_2x16(p3, y[3 % REGISTERS]);
+                }
+            }
+
+            self.bias + y.iter().sum::<i32x16>().reduce_sum().shr(9)
         }
-
-        #[cfg(not(target_feature = "avx512f"))]
-        #[cfg(target_feature = "avx2")]
-        unsafe {
-            self.avx2(us, them)
-        }
-
-        #[cfg(not(target_feature = "avx2"))]
-        #[cfg(target_feature = "ssse3")]
-        unsafe {
-            self.sse(us, them)
-        }
-
-        #[cfg(target_feature = "neon")]
-        unsafe {
-            self.neon(us, them)
-        }
-
-        #[cfg(not(target_feature = "avx2"))]
-        #[cfg(not(target_feature = "ssse3"))]
-        #[cfg(not(target_feature = "neon"))]
-        self.scalar(us, them)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use test_strategy::proptest;
-
-    #[cfg(target_feature = "avx512f")]
-    #[proptest]
-    fn uses_avx512(o: Output<256>, i: AlignTo64<[[i16; 256]; 2]>) {
-        assert_eq!(unsafe { o.avx512(&i[0], &i[1]) }, o.scalar(&i[0], &i[1]));
-    }
-
-    #[cfg(target_feature = "avx2")]
-    #[proptest]
-    fn uses_avx2(o: Output<128>, i: AlignTo64<[[i16; 128]; 2]>) {
-        assert_eq!(unsafe { o.avx2(&i[0], &i[1]) }, o.scalar(&i[0], &i[1]));
-    }
-
-    #[cfg(target_feature = "ssse3")]
-    #[proptest]
-    fn uses_sse(o: Output<64>, i: AlignTo64<[[i16; 64]; 2]>) {
-        assert_eq!(unsafe { o.sse(&i[0], &i[1]) }, o.scalar(&i[0], &i[1]));
-    }
-
-    #[cfg(target_feature = "neon")]
-    #[proptest]
-    fn uses_neon(o: Output<64>, i: AlignTo64<[[i16; 64]; 2]>) {
-        assert_eq!(unsafe { o.neon(&i[0], &i[1]) }, o.scalar(&i[0], &i[1]));
     }
 }

--- a/lib/nnue/transformer.rs
+++ b/lib/nnue/transformer.rs
@@ -1,5 +1,5 @@
 use crate::nnue::Feature;
-use crate::util::{AlignTo64, Assume, Integer};
+use crate::util::{Aligned, Assume, Integer};
 use bytemuck::Zeroable;
 use derive_more::with_trait::Debug;
 use std::hint::unreachable_unchecked;
@@ -11,10 +11,10 @@ use std::ops::{Add, AddAssign, Sub, SubAssign};
 #[cfg_attr(test, arbitrary(bound(T, T: From<i8>)))]
 #[debug("Transformer<{N}>")]
 pub struct Transformer<T, const N: usize> {
-    #[cfg_attr(test, map(|vs: [i8; N]| AlignTo64(vs.map(T::from))))]
-    pub bias: AlignTo64<[T; N]>,
-    #[cfg_attr(test, map(|vs: [[i8; N]; Feature::LEN]| AlignTo64(vs.map(|v| v.map(T::from)))))]
-    pub weight: AlignTo64<[[T; N]; Feature::LEN]>,
+    #[cfg_attr(test, map(|vs: [i8; N]| Aligned(vs.map(T::from))))]
+    pub bias: Aligned<[T; N]>,
+    #[cfg_attr(test, map(|vs: [[i8; N]; Feature::LEN]| Aligned(vs.map(|v| v.map(T::from)))))]
+    pub weight: Aligned<[[T; N]; Feature::LEN]>,
 }
 
 impl<T, const N: usize> Transformer<T, N>
@@ -183,7 +183,7 @@ mod tests {
         t: Transformer<i16, 3>,
         #[strategy(uniform3(-128..128i16))] acc: [i16; 3],
     ) {
-        let mut acc = AlignTo64(acc);
+        let mut acc = Aligned(acc);
         t.refresh(&mut acc);
         assert_eq!(acc, t.bias);
     }

--- a/lib/simd.rs
+++ b/lib/simd.rs
@@ -1,0 +1,5 @@
+mod mul2x16;
+mod muladd2x16;
+
+pub use mul2x16::*;
+pub use muladd2x16::*;

--- a/lib/simd/mul2x16.rs
+++ b/lib/simd/mul2x16.rs
@@ -1,0 +1,190 @@
+use std::mem::{transmute, transmute_copy};
+pub use std::simd::{LaneCount, SupportedLaneCount, prelude::*};
+
+/// Trait for [`Simd<i16, _>` ] types that implement `mul_2x16`.
+pub trait Mul2x16: SimdInt<Scalar = i16> {
+    /// The output [`Simd<i32, _>` ].
+    type Output: SimdInt<Scalar = i32>;
+
+    /// Multiplies with the corresponding group of 2 non-negative `i16` in `x` and sums up as `i32`.
+    fn mul_2x16(self, x: Self) -> Self::Output;
+}
+
+#[allow(unused)]
+#[inline(always)]
+fn fallback<const M: usize, const N: usize>(
+    w: Simd<i16, M>,
+    x: Simd<i16, M>,
+) -> <Simd<i16, M> as Mul2x16>::Output
+where
+    LaneCount<M>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
+    Simd<i16, M>: Mul2x16,
+    Simd<i16, N>: Mul2x16,
+{
+    const { assert!(M == 2 * N) }
+
+    unsafe {
+        let w = transmute_copy::<Simd<i16, M>, [Simd<i16, N>; 2]>(&w);
+        let x = transmute_copy::<Simd<i16, M>, [Simd<i16, N>; 2]>(&x);
+        transmute_copy::<[<Simd<i16, N> as Mul2x16>::Output; 2], <Simd<i16, M> as Mul2x16>::Output>(
+            &[w[0].mul_2x16(x[0]), w[1].mul_2x16(x[1])],
+        )
+    }
+}
+
+impl Mul2x16 for i16x32 {
+    type Output = i32x16;
+
+    #[inline(always)]
+    #[cfg(target_feature = "avx512bw")]
+    fn mul_2x16(self, x: Self) -> Self::Output {
+        debug_assert!(x.simd_ge(Simd::splat(0)).all());
+
+        unsafe {
+            use std::arch::x86_64::*;
+            let w = transmute::<Self, __m512i>(self);
+            let x = transmute::<Self, __m512i>(x);
+            transmute::<__m512i, Self::Output>(_mm512_madd_epi16(x, w))
+        }
+    }
+
+    #[inline(always)]
+    #[cfg(not(target_feature = "avx512bw"))]
+    fn mul_2x16(self, x: Self) -> Self::Output {
+        fallback::<32, 16>(self, x)
+    }
+}
+
+impl Mul2x16 for i16x16 {
+    type Output = i32x8;
+
+    #[inline(always)]
+    #[cfg(target_feature = "avx2")]
+    fn mul_2x16(self, x: Self) -> Self::Output {
+        debug_assert!(x.simd_ge(Simd::splat(0)).all());
+
+        unsafe {
+            use std::arch::x86_64::*;
+            let w = transmute::<Self, __m256i>(self);
+            let x = transmute::<Self, __m256i>(x);
+            transmute::<__m256i, Self::Output>(_mm256_madd_epi16(x, w))
+        }
+    }
+
+    #[inline(always)]
+    #[cfg(not(target_feature = "avx2"))]
+    fn mul_2x16(self, x: Self) -> Self::Output {
+        fallback::<16, 8>(self, x)
+    }
+}
+
+impl Mul2x16 for i16x8 {
+    type Output = i32x4;
+
+    #[inline(always)]
+    #[cfg(target_feature = "sse2")]
+    fn mul_2x16(self, x: Self) -> Self::Output {
+        debug_assert!(x.simd_ge(Simd::splat(0)).all());
+
+        unsafe {
+            use std::arch::x86_64::*;
+            let w = transmute::<Self, __m128i>(self);
+            let x = transmute::<Self, __m128i>(x);
+            transmute::<__m128i, Self::Output>(_mm_madd_epi16(x, w))
+        }
+    }
+
+    #[inline(always)]
+    #[cfg(target_feature = "neon")]
+    fn mul_2x16(self, x: Self) -> Self::Output {
+        unsafe {
+            use std::arch::aarch64::*;
+
+            let w = transmute::<Self, int16x8_t>(self);
+            let x = transmute::<Self, int16x8_t>(x);
+
+            let r = vmull_s16(vget_low_s16(w), vget_low_s16(x));
+            let s = vmull_high_s16(w, x);
+
+            transmute::<int32x4_t, Self::Output>(vpaddq_s32(r, s))
+        }
+    }
+
+    #[inline(always)]
+    #[cfg(not(target_feature = "sse2"))]
+    #[cfg(not(target_feature = "neon"))]
+    fn mul_2x16(self, x: Self) -> Self::Output {
+        fallback::<8, 4>(self, x)
+    }
+}
+
+impl Mul2x16 for i16x4 {
+    type Output = i32x2;
+
+    #[inline(always)]
+    fn mul_2x16(self, x: Self) -> Self::Output {
+        fallback::<4, 2>(self, x)
+    }
+}
+
+impl Mul2x16 for i16x2 {
+    type Output = i32x1;
+
+    #[inline(always)]
+    fn mul_2x16(self, x: Self) -> Self::Output {
+        unsafe {
+            transmute::<i32, Self::Output>((self.cast::<i32>() * x.cast::<i32>()).reduce_sum())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::{array::*, prelude::Strategy};
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn for_i32x16(
+        #[strategy(uniform32(-128i16..=127i16).prop_map(i16x32::from_array))] w: i16x32,
+        #[strategy(uniform32(0i16..=127i16).prop_map(i16x32::from_array))] x: i16x32,
+    ) {
+        assert_eq!(w.mul_2x16(x), fallback::<32, 16>(w, x));
+    }
+
+    #[proptest]
+    fn for_i32x8(
+        #[strategy(uniform16(-128i16..=127i16).prop_map(i16x16::from_array))] w: i16x16,
+        #[strategy(uniform16(0i16..=127i16).prop_map(i16x16::from_array))] x: i16x16,
+    ) {
+        assert_eq!(w.mul_2x16(x), fallback::<16, 8>(w, x));
+    }
+
+    #[proptest]
+    fn for_i32x4(
+        #[strategy(uniform8(-128i16..=127i16).prop_map(i16x8::from_array))] w: i16x8,
+        #[strategy(uniform8(0i16..=127i16).prop_map(i16x8::from_array))] x: i16x8,
+    ) {
+        assert_eq!(w.mul_2x16(x), fallback::<8, 4>(w, x));
+    }
+
+    #[proptest]
+    fn for_i32x2(
+        #[strategy(uniform4(-128i16..=127i16).prop_map(i16x4::from_array))] w: i16x4,
+        #[strategy(uniform4(0i16..=127i16).prop_map(i16x4::from_array))] x: i16x4,
+    ) {
+        assert_eq!(w.mul_2x16(x), fallback::<4, 2>(w, x));
+    }
+
+    #[proptest]
+    fn for_i32x1(
+        #[strategy(uniform2(-128i16..=127i16).prop_map(i16x2::from_array))] w: i16x2,
+        #[strategy(uniform2(0i16..=127i16).prop_map(i16x2::from_array))] x: i16x2,
+    ) {
+        assert_eq!(
+            w.mul_2x16(x).reduce_sum(),
+            (w.cast::<i32>() * x.cast::<i32>()).reduce_sum()
+        );
+    }
+}

--- a/lib/simd/muladd2x16.rs
+++ b/lib/simd/muladd2x16.rs
@@ -1,0 +1,156 @@
+pub use std::simd::prelude::*;
+
+/// Trait for [`Simd<i16, _>` ] types that implement `mul_add_2x16`.
+pub trait MulAdd2x16: SimdInt<Scalar = i16> {
+    /// The output [`Simd<i32, _>` ].
+    type Output: SimdInt<Scalar = i32>;
+
+    /// Multiplies with the corresponding group of 2 non-negative `i16` in `x` and sums up with the corresponding `i32` in `y`.
+    fn mul_add_2x16(self, x: Self, y: Self::Output) -> Self::Output;
+}
+
+impl MulAdd2x16 for i16x32 {
+    type Output = i32x16;
+
+    #[inline(always)]
+    #[cfg(target_feature = "avx512vnni")]
+    fn mul_add_2x16(self, x: Self, y: Self::Output) -> Self::Output {
+        debug_assert!(x.simd_ge(Simd::splat(0)).all());
+
+        unsafe {
+            use std::{arch::x86_64::*, mem::transmute};
+            transmute::<__m512i, Self::Output>(_mm512_dpwssd_epi32(
+                transmute::<Self::Output, __m512i>(y),
+                transmute::<Self, __m512i>(x),
+                transmute::<Self, __m512i>(self),
+            ))
+        }
+    }
+
+    #[inline(always)]
+    #[cfg(not(target_feature = "avx512vnni"))]
+    fn mul_add_2x16(self, x: Self, y: Self::Output) -> Self::Output {
+        crate::simd::Mul2x16::mul_2x16(self, x) + y
+    }
+}
+
+impl MulAdd2x16 for i16x16 {
+    type Output = i32x8;
+
+    #[inline(always)]
+    #[cfg(all(target_feature = "avx512vnni", target_feature = "avx512vl"))]
+    fn mul_add_2x16(self, x: Self, y: Self::Output) -> Self::Output {
+        debug_assert!(x.simd_ge(Simd::splat(0)).all());
+
+        unsafe {
+            use std::{arch::x86_64::*, mem::transmute};
+            transmute::<__m256i, Self::Output>(_mm256_dpwssd_epi32(
+                transmute::<Self::Output, __m256i>(y),
+                transmute::<Self, __m256i>(x),
+                transmute::<Self, __m256i>(self),
+            ))
+        }
+    }
+
+    #[inline(always)]
+    #[cfg(not(all(target_feature = "avx512vnni", target_feature = "avx512vl")))]
+    fn mul_add_2x16(self, x: Self, y: Self::Output) -> Self::Output {
+        crate::simd::Mul2x16::mul_2x16(self, x) + y
+    }
+}
+
+impl MulAdd2x16 for i16x8 {
+    type Output = i32x4;
+
+    #[inline(always)]
+    #[cfg(all(target_feature = "avx512vnni", target_feature = "avx512vl"))]
+    fn mul_add_2x16(self, x: Self, y: Self::Output) -> Self::Output {
+        debug_assert!(x.simd_ge(Simd::splat(0)).all());
+
+        unsafe {
+            use std::{arch::x86_64::*, mem::transmute};
+            transmute::<__m128i, Self::Output>(_mm_dpwssd_epi32(
+                transmute::<Self::Output, __m128i>(y),
+                transmute::<Self, __m128i>(x),
+                transmute::<Self, __m128i>(self),
+            ))
+        }
+    }
+
+    #[inline(always)]
+    #[cfg(not(all(target_feature = "avx512vnni", target_feature = "avx512vl")))]
+    fn mul_add_2x16(self, x: Self, y: Self::Output) -> Self::Output {
+        crate::simd::Mul2x16::mul_2x16(self, x) + y
+    }
+}
+
+impl MulAdd2x16 for i16x4 {
+    type Output = i32x2;
+
+    #[inline(always)]
+    fn mul_add_2x16(self, x: Self, y: Self::Output) -> Self::Output {
+        crate::simd::Mul2x16::mul_2x16(self, x) + y
+    }
+}
+
+impl MulAdd2x16 for i16x2 {
+    type Output = i32x1;
+
+    #[inline(always)]
+    fn mul_add_2x16(self, x: Self, y: Self::Output) -> Self::Output {
+        crate::simd::Mul2x16::mul_2x16(self, x) + y
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::simd::Mul2x16;
+    use proptest::{array::*, prelude::Strategy};
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn for_i32x16(
+        #[strategy(uniform32(-128i16..=127i16).prop_map(i16x32::from_array))] w: i16x32,
+        #[strategy(uniform32(0i16..=127i16).prop_map(i16x32::from_array))] x: i16x32,
+        #[strategy(uniform16(-128i32..=127i32).prop_map(i32x16::from_array))] y: i32x16,
+    ) {
+        assert_eq!(w.mul_add_2x16(x, y), w.mul_2x16(x) + y);
+    }
+
+    #[proptest]
+    fn for_i32x8(
+        #[strategy(uniform16(-128i16..=127i16).prop_map(i16x16::from_array))] w: i16x16,
+        #[strategy(uniform16(0i16..=127i16).prop_map(i16x16::from_array))] x: i16x16,
+        #[strategy(uniform8(-128i32..=127i32).prop_map(i32x8::from_array))] y: i32x8,
+    ) {
+        assert_eq!(w.mul_add_2x16(x, y), w.mul_2x16(x) + y);
+    }
+
+    #[proptest]
+    fn for_i32x4(
+        #[strategy(uniform8(-128i16..=127i16).prop_map(i16x8::from_array))] w: i16x8,
+        #[strategy(uniform8(0i16..=127i16).prop_map(i16x8::from_array))] x: i16x8,
+        #[strategy(uniform4(-128i32..=127i32).prop_map(i32x4::from_array))] y: i32x4,
+    ) {
+        assert_eq!(w.mul_add_2x16(x, y), w.mul_2x16(x) + y);
+    }
+
+    #[proptest]
+    fn for_i32x2(
+        #[strategy(uniform4(-128i16..=127i16).prop_map(i16x4::from_array))] w: i16x4,
+        #[strategy(uniform4(0i16..=127i16).prop_map(i16x4::from_array))] x: i16x4,
+        #[strategy(uniform2(-128i32..=127i32).prop_map(i32x2::from_array))] y: i32x2,
+    ) {
+        assert_eq!(w.mul_add_2x16(x, y), w.mul_2x16(x) + y);
+    }
+
+    #[proptest]
+    fn for_i32x1(
+        #[strategy(uniform2(-128i16..=127i16).prop_map(i16x2::from_array))] w: i16x2,
+        #[strategy(uniform2(0i16..=127i16).prop_map(i16x2::from_array))] x: i16x2,
+        #[strategy(uniform1(-128i32..=127i32).prop_map(i32x1::from_array))] y: i32x1,
+    ) {
+        assert_eq!(w.mul_add_2x16(x, y), w.mul_2x16(x) + y);
+    }
+}

--- a/lib/util.rs
+++ b/lib/util.rs
@@ -1,4 +1,4 @@
-mod align;
+mod aligned;
 mod assume;
 mod binary;
 mod bits;
@@ -9,7 +9,7 @@ mod memory;
 pub mod parsers;
 pub mod thread;
 
-pub use align::*;
+pub use aligned::*;
 pub use assume::*;
 pub use binary::*;
 pub use bits::*;

--- a/lib/util/aligned.rs
+++ b/lib/util/aligned.rs
@@ -6,4 +6,4 @@ use derive_more::with_trait::{Deref, DerefMut, IntoIterator};
 )]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(align(64))]
-pub struct AlignTo64<T>(#[into_iterator(owned, ref, ref_mut)] pub T);
+pub struct Aligned<T>(#[into_iterator(owned, ref, ref_mut)] pub T);


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 0.84 +/- 1.97, nElo: 1.57 +/- 3.69
LOS: 79.82 %, DrawRatio: 51.98 %, PairsRatio: 1.02
Games: 33996, Wins: 8605, Losses: 8523, Draws: 16868, Points: 17039.0 (50.12 %)
Ptnml(0-2): [237, 3812, 8836, 3858, 255], WL/DD Ratio: 0.92
LLR: 2.90 (100.3%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```