### PR TITLE
Slightly improve the NNUE SIMD speed

### DIFF
--- a/bin/trainer.rs
+++ b/bin/trainer.rs
@@ -318,7 +318,7 @@ impl Orchestrator {
                 SavedFormat::id("l12w")
                     .transpose()
                     .round()
-                    .quantise::<i8>(HLS as _),
+                    .quantise::<i8>(HLS),
                 SavedFormat::id("l12b"),
                 SavedFormat::id("l23w").transpose(),
                 SavedFormat::id("l23b"),

--- a/lib/nnue.rs
+++ b/lib/nnue.rs
@@ -28,10 +28,10 @@ pub use value::*;
 pub const FTQ: i16 = 255;
 
 /// Quantization constant for the hidden layers.
-pub const HLQ: i32 = 127;
+pub const HLQ: i16 = 127;
 
 /// Quantization scale for the hidden layers.
-pub const HLS: i32 = 64;
+pub const HLS: i16 = 64;
 
 const unsafe fn copy_bytes<T>(dst: &mut T, src: &[u8]) -> usize {
     let len = size_of_val(dst);

--- a/lib/nnue/layer23.rs
+++ b/lib/nnue/layer23.rs
@@ -1,9 +1,7 @@
 use crate::nnue::{Layer, Layer2, Layer3, Synapse};
 use crate::{simd::*, util::Aligned};
 use bytemuck::Zeroable;
-use std::array;
-use std::mem::transmute;
-use std::ops::{Add, Mul};
+use std::{array::from_fn as each, mem::transmute};
 
 const I: usize = Layer2::LEN;
 const O: usize = Layer3::LEN;
@@ -29,25 +27,25 @@ impl<S: for<'a> Synapse<Input<'a> = Layer3<'a>>> Synapse for Layer23<S> {
             let is = transmute::<&[f32; I], &[R2<f32>; I / W2]>(input);
 
             let is = [
-                is.map(|i| i.mul(i).simd_clamp(Simd::splat(0.), Simd::splat(1.))),
-                is.map(|i| i.simd_clamp(Simd::splat(0.), Simd::splat(1.))),
+                is.map(|i| i.powi::<2>().simd_clamp(Simd::splat(0.), Simd::splat(1.))),
+                is.map(|i| i.powi::<1>().simd_clamp(Simd::splat(0.), Simd::splat(1.))),
             ];
 
             const K: usize = usize::max(8 * W2 / O, 1);
-            let mut accumulators = [[Simd::splat(0.); K]; O / W2];
-            let xs = transmute::<&[[R2<f32>; I / W2]; 2], &[f32; 2 * I]>(&is);
-            let ws = transmute::<&[[f32; 1]; 2 * I * O], &[R2<f32>; 2 * I * O / W2]>(&self.weight);
-            for (i, xs) in xs.iter().array_chunks::<K>().enumerate() {
-                let xs: [_; K] = array::from_fn(|k| Simd::splat(*xs[k]));
-                for (j, acc) in accumulators.iter_mut().enumerate() {
-                    *acc = array::from_fn(|k| ws[(K * i + k) * O / W2 + j].mul_add(xs[k], acc[k]));
-                }
+            let mut acc = [[Simd::splat(0.); K]; O / W2];
+            let xs = transmute::<&[[R2<f32>; I / W2]; 2], &[[f32; K]; 2 * I / K]>(&is);
+            let ws = transmute::<&[[f32; 1]; 2 * I * O], &[[[R2<f32>; O / W2]; K]; 2 * I / K]>(
+                &self.weight,
+            );
+
+            for (i, xs) in xs.iter().enumerate() {
+                acc = each(|j| each(|k| ws[i][k][j].mul_add(Simd::splat(xs[k]), acc[j][k])));
             }
 
             let mut output = self.bias;
             let os = transmute::<&mut [f32; O], &mut [R2<f32>; O / W2]>(&mut output);
-            for (o, acc) in os.iter_mut().zip(accumulators) {
-                *o = acc.iter().sum::<R2<f32>>().add(*o);
+            for (o, a) in os.iter_mut().zip(acc) {
+                *o += a.iter().sum::<R2<f32>>();
             }
 
             self.next.forward(&output)

--- a/lib/simd.rs
+++ b/lib/simd.rs
@@ -3,12 +3,14 @@ mod mul4x8;
 mod muladd4x8;
 mod mulhi;
 mod pack;
+mod powi;
 
 pub use halve::*;
 pub use mul4x8::*;
 pub use muladd4x8::*;
 pub use mulhi::*;
 pub use pack::*;
+pub use powi::*;
 
 pub use std::simd::{StdFloat, prelude::*};
 

--- a/lib/simd/powi.rs
+++ b/lib/simd/powi.rs
@@ -1,0 +1,63 @@
+use std::ops::MulAssign;
+use std::simd::{LaneCount, SimdElement, SupportedLaneCount, prelude::*};
+
+/// Trait for [`Simd<_, _>` ] types that implement `powi`.
+pub trait Powi {
+    /// Raises `self` to the power of `E`.
+    fn powi<const E: u32>(self) -> Self;
+}
+
+impl<T, const N: usize> Powi for Simd<T, N>
+where
+    T: SimdElement + From<i8>,
+    LaneCount<N>: SupportedLaneCount,
+    Self: MulAssign,
+{
+    #[inline(always)]
+    fn powi<const E: u32>(mut self) -> Self {
+        let mut result = Self::splat(1.into());
+
+        let mut exp = E;
+        for _ in 0..32 - E.leading_zeros() {
+            if exp & 1 == 1 {
+                result *= self;
+            }
+
+            self *= self;
+            exp >>= 1;
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::{array::UniformArrayStrategy, prelude::Strategy};
+    use std::simd::StdFloat;
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn for_i32(
+        #[strategy(UniformArrayStrategy::new(-128i32..=127i32).prop_map(i32x4::from_array))]
+        x: i32x4,
+    ) {
+        assert_eq!(x.powi::<1>(), x);
+        assert_eq!(x.powi::<2>(), x * x);
+        assert_eq!(x.powi::<3>(), x * x * x);
+        assert_eq!(x.powi::<4>(), x * x * x * x);
+    }
+
+    #[proptest]
+    fn for_f32(
+        #[strategy(UniformArrayStrategy::new(-128f32..=127f32).prop_map(f32x4::from_array))]
+        x: f32x4,
+    ) {
+        let x = x.floor();
+        assert_eq!(x.powi::<1>(), x);
+        assert_eq!(x.powi::<2>(), x * x);
+        assert_eq!(x.powi::<3>(), x * x * x);
+        assert_eq!(x.powi::<4>(), x * x * x * x);
+    }
+}


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 4.92 +/- 2.96, nElo: 9.13 +/- 5.49
LOS: 99.94 %, DrawRatio: 51.21 %, PairsRatio: 1.11
Games: 15402, Wins: 4025, Losses: 3807, Draws: 7570, Points: 7810.0 (50.71 %)
Ptnml(0-2): [105, 1679, 3944, 1839, 134], WL/DD Ratio: 0.95
LLR: 2.92 (101.0%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```