### PR TITLE
Define struct Slice as a hugepage-backed memory allocator

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -12,6 +12,7 @@
     coverage_attribute,
     gen_blocks,
     iter_array_chunks,
+    pointer_is_aligned_to,
     portable_simd,
     ptr_as_ref_unchecked,
     slice_swap_unchecked,

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -1,8 +1,8 @@
 use crate::chess::{Move, Position};
 use crate::nnue::{Evaluator, Value};
-use crate::util::{Assume, Bounded, Integer, Memory};
+use crate::util::{Assume, Bounded, Integer, Memory, Slice};
 use crate::{params::Params, search::*, syzygy::Syzygy};
-use bytemuck::{Zeroable, try_zeroed_slice_box};
+use bytemuck::Zeroable;
 use derive_more::with_trait::{Deref, DerefMut, Display, Error};
 use futures::channel::mpsc::{UnboundedReceiver, unbounded};
 use futures::stream::{FusedStream, Stream, StreamExt};
@@ -1041,7 +1041,7 @@ pub struct Engine {
     tt: Memory<Transposition>,
     syzygy: Syzygy,
     executor: Executor,
-    searchers: Box<[Searcher]>,
+    searchers: Slice<Searcher>,
 }
 
 #[cfg(test)]
@@ -1074,7 +1074,7 @@ impl Engine {
             tt: Memory::new(options.hash.get()),
             syzygy: Syzygy::new(&options.syzygy),
             executor: Executor::new(options.threads),
-            searchers: try_zeroed_slice_box(options.threads.cast()).assume(),
+            searchers: Slice::new(options.threads.cast()).unwrap(),
         }
     }
 

--- a/lib/util.rs
+++ b/lib/util.rs
@@ -5,6 +5,7 @@ mod bits;
 mod bounded;
 mod integer;
 mod memory;
+mod slice;
 
 pub mod parsers;
 pub mod thread;
@@ -16,3 +17,4 @@ pub use bits::*;
 pub use bounded::*;
 pub use integer::*;
 pub use memory::*;
+pub use slice::*;

--- a/lib/util/memory.rs
+++ b/lib/util/memory.rs
@@ -1,6 +1,6 @@
-use crate::util::{Assume, Binary, Bits, Integer, Unsigned};
+use crate::util::{Assume, Binary, Bits, Integer, Slice, Unsigned};
 use atomic::Atomic;
-use bytemuck::{Zeroable, try_zeroed_slice_box};
+use bytemuck::Zeroable;
 use derive_more::with_trait::{Debug, Deref, DerefMut};
 use std::ops::{Index, IndexMut};
 use std::{marker::PhantomData, mem::size_of, sync::atomic::Ordering};
@@ -86,7 +86,7 @@ pub struct Memory<
     Option<Latch<T, U>>: Binary,
 {
     #[allow(clippy::type_complexity)]
-    data: Box<[Slot<<Option<Latch<T, U>> as Binary>::Bits>]>,
+    data: Slice<Slot<<Option<Latch<T, U>> as Binary>::Bits>>,
 }
 
 #[cfg(test)]
@@ -105,8 +105,8 @@ where
                 let cap = map.len().next_power_of_two();
 
                 #[allow(clippy::type_complexity)]
-                let mut data: Box<[Slot<<Option<Latch<T, U>> as Binary>::Bits>]> =
-                    try_zeroed_slice_box(cap).assume();
+                let mut data: Slice<Slot<<Option<Latch<T, U>> as Binary>::Bits>> =
+                    Slice::new(cap).unwrap();
 
                 if cap > 0 {
                     for (k, v) in map {
@@ -132,7 +132,7 @@ where
         let cap = (1 + size / 2).next_power_of_two() / size_of::<Latch<T, U>>();
 
         Memory {
-            data: try_zeroed_slice_box(cap).assume(),
+            data: Slice::new(cap).unwrap(),
         }
     }
 

--- a/lib/util/slice.rs
+++ b/lib/util/slice.rs
@@ -1,0 +1,100 @@
+use bytemuck::Zeroable;
+use memmap2::{MmapMut, MmapOptions};
+use std::ops::{Deref, DerefMut};
+use std::{alloc::Layout, io, slice};
+
+const HUGEPAGE_SIZE: usize = 1 << 21;
+
+/// A hugepage-backed slice of `T`.
+///
+/// Memory is guaranteed to be zero-initialized on all platforms.
+#[derive(Debug)]
+pub struct Slice<T> {
+    ptr: *const T,
+    len: usize,
+    _mmap: MmapMut,
+}
+
+unsafe impl<T: Send> Send for Slice<T> {}
+unsafe impl<T: Sync> Sync for Slice<T> {}
+
+impl<T: Zeroable> Slice<T> {
+    /// Allocates hugepage-backed block of memory for `len` instances of `T`.
+    pub fn new(len: usize) -> io::Result<Self> {
+        let layout = Layout::array::<T>(len).map_err(|_| io::ErrorKind::OutOfMemory)?;
+        let align = layout.align().max(64); // align to cache line
+        let size = (layout.size() + align - 1).next_multiple_of(HUGEPAGE_SIZE);
+        let mmap = MmapOptions::new().len(size).populate().map_anon()?;
+
+        #[cfg(target_os = "linux")]
+        mmap.advise(memmap2::Advice::HugePage)?;
+
+        let ptr = mmap.as_ptr();
+        let offset = ptr.align_offset(align);
+
+        Ok(Slice {
+            ptr: ptr.wrapping_add(offset) as _,
+            len,
+            _mmap: mmap,
+        })
+    }
+}
+
+impl<T> Deref for Slice<T> {
+    type Target = [T];
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+impl<T> DerefMut for Slice<T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { slice::from_raw_parts_mut(self.ptr as _, self.len) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_strategy::proptest;
+
+    #[derive(Zeroable)]
+    #[repr(align(4096))]
+    struct AlignedTo4096(#[allow(dead_code)] [u8; 4096]);
+
+    #[proptest]
+    fn is_aligned_to_type(#[strategy(1usize..1024)] n: usize) {
+        let slice: Slice<AlignedTo4096> = Slice::new(n)?;
+
+        assert_eq!(slice.len(), n);
+        assert!(slice.as_ptr().is_aligned());
+        assert!(slice._mmap.len().is_multiple_of(HUGEPAGE_SIZE));
+    }
+
+    #[proptest]
+    fn is_aligned_to_cache_line(#[strategy(1usize..1024)] n: usize) {
+        let slice: Slice<u32> = Slice::new(n)?;
+
+        assert_eq!(slice.len(), n);
+        assert!(slice.as_ptr().is_aligned_to(64));
+        assert!(slice._mmap.len().is_multiple_of(HUGEPAGE_SIZE));
+    }
+
+    #[proptest]
+    fn is_initialized_with_zero(#[strategy(1..(1usize << 20))] n: usize) {
+        let slice: Slice<u32> = Slice::new(n)?;
+        assert!(slice.iter().all(|&x| x == 0));
+    }
+
+    #[proptest]
+    fn is_mutable(#[strategy(1..(1usize << 20))] n: usize, #[strategy(0..#n)] i: usize, x: u32) {
+        let mut slice: Slice<u32> = Slice::new(n)?;
+
+        assert_eq!(slice[i], 0);
+        slice[i] = x;
+        assert_eq!(slice[i], x);
+    }
+}


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=1+0.01 option.Hash=64 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 64MB, UHO_Lichess_4852_v1.epd):
Elo: 2.83 +/- 3.13, nElo: 5.13 +/- 5.68
LOS: 96.16 %, DrawRatio: 49.67 %, PairsRatio: 1.07
Games: 14388, Wins: 3744, Losses: 3627, Draws: 7017, Points: 7252.5 (50.41 %)
Ptnml(0-2): [125, 1627, 3573, 1744, 125], WL/DD Ratio: 0.96
LLR: 2.92 (101.0%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```