### PR TITLE
Parallelize zeroing of huge pages

### DIFF
--- a/lib/util/integer.rs
+++ b/lib/util/integer.rs
@@ -9,7 +9,7 @@ use std::{num::*, ops::*};
 /// # Safety
 ///
 /// Must only be implemented for types that can be safely transmuted to and from [`Integer::Repr`].
-pub unsafe trait Integer: Copy {
+pub unsafe trait Integer: Send + Sync + Copy {
     /// The equivalent primitive integer type.
     type Repr: Primitive;
 


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 4.53 +/- 3.80, nElo: 8.39 +/- 7.04
LOS: 99.02 %, DrawRatio: 52.17 %, PairsRatio: 1.11
Games: 9354, Wins: 2477, Losses: 2355, Draws: 4522, Points: 4738.0 (50.65 %)
Ptnml(0-2): [81, 978, 2440, 1094, 84], WL/DD Ratio: 0.99
LLR: 2.91 (100.6%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```