### PR TITLE
Avoid out of memory on ucinewgame

### DIFF
--- a/lib/syzygy.rs
+++ b/lib/syzygy.rs
@@ -1,6 +1,6 @@
 use crate::search::{Line, Ply, Pv};
 use crate::{chess::Position, util::Integer};
-use std::{fs::read_dir, path::PathBuf};
+use std::{fs::read_dir, path::Path};
 
 mod dtz;
 mod fs;
@@ -24,7 +24,7 @@ pub struct Syzygy {
 
 impl Syzygy {
     /// Initializes the the tablebase from the files in `path`.
-    pub fn new<'a, I: IntoIterator<Item = &'a PathBuf>>(paths: I) -> Self {
+    pub fn new<P: AsRef<Path>, I: IntoIterator<Item = P>>(paths: I) -> Self {
         let mut syzygy = Self::default();
 
         for path in paths {
@@ -117,7 +117,7 @@ impl Syzygy {
 mod tests {
     use super::*;
     use std::fs::{File, create_dir_all};
-    use std::io::Write;
+    use std::{io::Write, path::PathBuf};
     use tempfile::TempDir;
     use test_strategy::proptest;
 
@@ -141,7 +141,7 @@ mod tests {
 
     #[proptest(cases = 1)]
     fn new_with_empty_paths() {
-        let syzygy = Syzygy::new(&[]);
+        let syzygy = Syzygy::new::<&PathBuf, _>(&[]);
         assert_eq!(syzygy.max_pieces(), 0);
     }
 

--- a/lib/util/memory.rs
+++ b/lib/util/memory.rs
@@ -186,6 +186,12 @@ where
         let bits = self.data[key].load(Ordering::Relaxed);
         Option::<Latch<T, U>>::decode(bits)?.open(key)
     }
+
+    /// Clears all entries.
+    #[inline(always)]
+    pub fn clear(&mut self) {
+        self.data.clear();
+    }
 }
 
 impl<T> Index<Key> for [Slot<T>] {


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 1.40 +/- 2.36, nElo: 2.58 +/- 4.35
LOS: 87.75 %, DrawRatio: 50.39 %, PairsRatio: 1.03
Games: 24538, Wins: 6393, Losses: 6294, Draws: 11851, Points: 12318.5 (50.20 %)
Ptnml(0-2): [189, 2810, 6182, 2889, 199], WL/DD Ratio: 1.01
LLR: 2.91 (100.7%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```