### PR TITLE
Do not report decisive tb scores as mate

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -1132,10 +1132,10 @@ mod tests {
         mut e: Engine,
         #[filter(#pos.outcome().is_none())] pos: Evaluator,
         #[map(|s: Selector| s.select(#pos.moves().unpack()))] m: Move,
-        #[filter(#b.mate() == Mate::None)] b: Score,
+        #[filter(!#b.is_winning() && !#b.is_losing())] b: Score,
         was_pv: bool,
         d: Depth,
-        #[filter(#s.mate() == Mate::None && #s >= #b)] s: Score,
+        #[filter(!#s.is_winning() && #s >= #b)] s: Score,
         cut: bool,
     ) {
         let tpos = Transposition::new(ScoreBound::Lower(s), Depth::upper(), Some(m), was_pv);
@@ -1159,10 +1159,10 @@ mod tests {
         mut e: Engine,
         #[filter(#pos.outcome().is_none())] pos: Evaluator,
         #[map(|s: Selector| s.select(#pos.moves().unpack()))] m: Move,
-        #[filter(#b.mate() == Mate::None)] b: Score,
+        #[filter(!#b.is_winning() && !#b.is_losing())] b: Score,
         was_pv: bool,
         d: Depth,
-        #[filter(#s.mate() == Mate::None && #s < #b)] s: Score,
+        #[filter(!#s.is_losing() && #s < #b)] s: Score,
         cut: bool,
     ) {
         let tpos = Transposition::new(ScoreBound::Upper(s), Depth::upper(), Some(m), was_pv);
@@ -1186,10 +1186,10 @@ mod tests {
         mut e: Engine,
         #[filter(#pos.outcome().is_none())] pos: Evaluator,
         #[map(|s: Selector| s.select(#pos.moves().unpack()))] m: Move,
-        #[filter(#b.mate() == Mate::None)] b: Score,
+        #[filter(!#b.is_winning() && !#b.is_losing())] b: Score,
         was_pv: bool,
         d: Depth,
-        #[filter(#s.mate() == Mate::None)] s: Score,
+        #[filter(!#s.is_winning() && !#s.is_losing())] s: Score,
         cut: bool,
     ) {
         let tpos = Transposition::new(ScoreBound::Exact(s), Depth::upper(), Some(m), was_pv);


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 30000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 0.40 +/- 1.62, nElo: 0.75 +/- 3.03
LOS: 68.58 %, DrawRatio: 52.57 %, PairsRatio: 1.00
Games: 50506, Wins: 12988, Losses: 12930, Draws: 24588, Points: 25282.0 (50.06 %)
Ptnml(0-2): [367, 5622, 13276, 5562, 426], WL/DD Ratio: 0.98
LLR: 2.93 (101.2%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```