### PR TITLE
Improve NUMA friendliness by using the executor to reset the engine

### DIFF
--- a/lib/search/executor.rs
+++ b/lib/search/executor.rs
@@ -100,7 +100,6 @@ impl Executor {
     }
 
     /// Executes `f` on every thread.
-    #[must_use]
     #[inline(always)]
     pub fn execute<F: Fn(usize) + Send + Sync + 'static>(&mut self, f: F) -> Task<'_> {
         unsafe { *self.shared.job.get().as_mut_unchecked() = Some(Box::new(f)) };


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 50000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 6.17 +/- 4.35, nElo: 11.50 +/- 8.11
LOS: 99.73 %, DrawRatio: 51.76 %, PairsRatio: 1.16
Games: 7044, Wins: 1849, Losses: 1724, Draws: 3471, Points: 3584.5 (50.89 %)
Ptnml(0-2): [57, 728, 1823, 861, 53], WL/DD Ratio: 0.94
LLR: 2.91 (100.7%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```