### PR TITLE
Share initial search setup across all threads

### DIFF
--- a/lib/syzygy.rs
+++ b/lib/syzygy.rs
@@ -1,4 +1,4 @@
-use crate::search::{Line, Ply, Pv};
+use crate::search::{Line, Moves, Ply, Pv};
 use crate::{chess::Position, util::Int};
 use std::{fs::read_dir, io, path::Path};
 
@@ -71,7 +71,7 @@ impl Syzygy {
     }
 
     /// This [`Position`]'s best [`Pv`].
-    pub fn best(&self, pos: &Position) -> Option<Pv<1>> {
+    pub fn best(&self, pos: &Position, moves: &Moves) -> Option<Pv<1>> {
         if pos.occupied().len() > self.max_pieces() {
             return None;
         }
@@ -81,7 +81,7 @@ impl Syzygy {
         let mut best_gaining = false;
         let mut best_move = None;
 
-        for m in pos.moves().unpack() {
+        for m in moves.iter() {
             let mut next = pos.clone();
             next.play(m);
 

--- a/tests/syzygy.rs
+++ b/tests/syzygy.rs
@@ -431,7 +431,7 @@ fn probing_syzygy_tablebase_finds_best_move(
 
     assert_eq!(
         SYZYGY
-            .best(&pos)
+            .best(&pos, &pos.moves().unpack().collect())
             .and_then(|pv| Some((pv.score(), pv.head()?.to_string()))),
         if !m.is_empty() {
             Some((wdl.to_score(Ply::new(0)), m.to_string()))


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 50000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 8 -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=1+0.01 option.Threads=2 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 2t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 1.29 +/- 2.30, nElo: 2.37 +/- 4.22
LOS: 86.47 %, DrawRatio: 49.18 %, PairsRatio: 1.02
Games: 26042, Wins: 6656, Losses: 6559, Draws: 12827, Points: 13069.5 (50.19 %)
Ptnml(0-2): [167, 3115, 6404, 3124, 211], WL/DD Ratio: 0.94
LLR: 2.91 (100.7%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```