### PR TITLE
Leverage simd to optimize cached accumulator refresh

### DIFF
--- a/lib/chess/bitboard.rs
+++ b/lib/chess/bitboard.rs
@@ -30,7 +30,7 @@ use std::fmt::{self, Formatter, Write};
 )]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(transparent)]
-pub struct Bitboard(u64);
+pub struct Bitboard(pub u64);
 
 impl Debug for Bitboard {
     #[coverage(off)]

--- a/lib/chess/color.rs
+++ b/lib/chess/color.rs
@@ -1,5 +1,5 @@
 use crate::{chess::Flip, util::Int};
-use bytemuck::{Zeroable, ZeroableInOption};
+use bytemuck::Zeroable;
 use derive_more::with_trait::Display;
 use std::ops::Not;
 
@@ -13,8 +13,6 @@ pub enum Color {
     #[display("black")]
     Black,
 }
-
-unsafe impl ZeroableInOption for Color {}
 
 unsafe impl Int for Color {
     type Repr = u8;

--- a/lib/chess/file.rs
+++ b/lib/chess/file.rs
@@ -1,6 +1,6 @@
 use crate::chess::{Bitboard, Mirror, Rank, Transpose};
 use crate::util::{Assume, Int};
-use bytemuck::{Zeroable, ZeroableInOption};
+use bytemuck::Zeroable;
 use derive_more::with_trait::{Display, Error};
 use std::fmt::{self, Formatter, Write};
 use std::{ops::Sub, str::FromStr};
@@ -19,8 +19,6 @@ pub enum File {
     G,
     H,
 }
-
-unsafe impl ZeroableInOption for File {}
 
 impl File {
     /// Returns a [`Bitboard`] that only contains this file.

--- a/lib/chess/geometry.rs
+++ b/lib/chess/geometry.rs
@@ -1,5 +1,5 @@
 use crate::{chess::Color, util::Int};
-use bytemuck::{Zeroable, ZeroableInOption};
+use bytemuck::Zeroable;
 
 /// Trait for types that can be seen from a different perspective.
 pub trait Perspective<T>: Sized {
@@ -31,8 +31,6 @@ pub enum Side {
     Left,
     Right,
 }
-
-unsafe impl ZeroableInOption for Side {}
 
 unsafe impl Int for Side {
     type Repr = u8;

--- a/lib/chess/move.rs
+++ b/lib/chess/move.rs
@@ -1,6 +1,5 @@
 use crate::chess::{Bitboard, Flip, Perspective, Piece, Rank, Role, Square, Squares};
 use crate::util::{Assume, Binary, Bits, Int};
-use bytemuck::ZeroableInOption;
 use std::fmt::{self, Debug, Display, Formatter, Write};
 use std::{num::NonZeroU16, ops::RangeBounds};
 
@@ -108,8 +107,6 @@ impl Display for Move {
         Ok(())
     }
 }
-
-unsafe impl ZeroableInOption for Move {}
 
 impl Binary for Move {
     type Bits = Bits<u16, 16>;

--- a/lib/chess/piece.rs
+++ b/lib/chess/piece.rs
@@ -1,6 +1,6 @@
 use crate::chess::{Bitboard, Color, Flip, Magic, Perspective, Rank, Role, Square};
 use crate::util::{Assume, Int};
-use bytemuck::{Zeroable, ZeroableInOption, zeroed};
+use bytemuck::{Zeroable, zeroed};
 use derive_more::with_trait::{Display, Error};
 use std::fmt::{self, Formatter, Write};
 use std::{cell::SyncUnsafeCell, ops::Shl, str::FromStr};
@@ -201,8 +201,6 @@ impl Piece {
         }
     }
 }
-
-unsafe impl ZeroableInOption for Piece {}
 
 unsafe impl Int for Piece {
     type Repr = u8;

--- a/lib/chess/rank.rs
+++ b/lib/chess/rank.rs
@@ -1,6 +1,6 @@
 use crate::chess::{Bitboard, File, Flip, Transpose};
 use crate::util::{Assume, Int};
-use bytemuck::{Zeroable, ZeroableInOption};
+use bytemuck::Zeroable;
 use derive_more::with_trait::{Display, Error};
 use std::fmt::{self, Formatter, Write};
 use std::{ops::Sub, str::FromStr};
@@ -27,8 +27,6 @@ impl Rank {
         Bitboard::new(0x000000000000FF << (self.get() * 8))
     }
 }
-
-unsafe impl ZeroableInOption for Rank {}
 
 unsafe impl Int for Rank {
     type Repr = i8;

--- a/lib/chess/role.rs
+++ b/lib/chess/role.rs
@@ -1,5 +1,5 @@
 use crate::util::Int;
-use bytemuck::{Zeroable, ZeroableInOption};
+use bytemuck::Zeroable;
 use derive_more::with_trait::{Display, Error};
 use std::fmt::{self, Formatter, Write};
 use std::str::FromStr;
@@ -16,8 +16,6 @@ pub enum Role {
     Queen,
     King,
 }
-
-unsafe impl ZeroableInOption for Role {}
 
 unsafe impl Int for Role {
     type Repr = u8;

--- a/lib/chess/square.rs
+++ b/lib/chess/square.rs
@@ -1,6 +1,6 @@
 use crate::chess::*;
 use crate::util::{Assume, Binary, Bits, Int};
-use bytemuck::{Zeroable, ZeroableInOption};
+use bytemuck::Zeroable;
 use derive_more::with_trait::{Display, Error, From};
 use std::fmt::{self, Formatter};
 use std::ops::{Add, AddAssign, Sub, SubAssign};
@@ -47,8 +47,6 @@ impl Square {
         Bitboard::new(1 << self.get())
     }
 }
-
-unsafe impl ZeroableInOption for Square {}
 
 unsafe impl Int for Square {
     type Repr = i8;

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -579,7 +579,7 @@ impl<'a> Searcher<'a> {
 
             let turn = self.stack.pos.turn();
             let pawns = self.stack.pos.pawns(turn);
-            if (self.stack.pos.material(turn) ^ pawns).len() > 1 {
+            if (self.stack.pos.by_color(turn) ^ pawns).len() > 1 {
                 if let Some(margin) = Self::nmp(depth) {
                     if transposed.score() - margin.to_int::<i16>() >= beta {
                         return Ok(transposed.truncate());

--- a/lib/syzygy/wdl.rs
+++ b/lib/syzygy/wdl.rs
@@ -1,6 +1,6 @@
 use crate::search::{Ply, Score};
 use crate::{syzygy::Dtz, util::Int};
-use bytemuck::{Zeroable, ZeroableInOption};
+use bytemuck::Zeroable;
 use std::ops::Neg;
 
 /// The possible outcomes of a final [`Position`](`crate::chess::Position`).
@@ -19,8 +19,6 @@ pub enum Wdl {
     /// Unconditional win.
     Win = 2,
 }
-
-unsafe impl ZeroableInOption for Wdl {}
 
 unsafe impl Int for Wdl {
     type Repr = i8;


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 50000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 7.72 +/- 3.85, nElo: 14.25 +/- 7.10
LOS: 100.00 %, DrawRatio: 50.84 %, PairsRatio: 1.18
Games: 9186, Wins: 2485, Losses: 2281, Draws: 4420, Points: 4695.0 (51.11 %)
Ptnml(0-2): [66, 969, 2335, 1141, 82], WL/DD Ratio: 1.02
LLR: 2.90 (100.5%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```