### PR TITLE
Remove initial pv seeding from tt

### DIFF
--- a/lib/search/info.rs
+++ b/lib/search/info.rs
@@ -1,4 +1,5 @@
 use crate::search::{Depth, Pv};
+use crate::util::Int;
 use derive_more::with_trait::{Constructor, Deref};
 use std::time::Duration;
 
@@ -42,5 +43,12 @@ impl Info {
     #[inline(always)]
     pub fn pv(&self) -> &Pv {
         &self.pv
+    }
+}
+
+impl From<Pv> for Info {
+    #[inline(always)]
+    fn from(pv: Pv) -> Self {
+        Info::new(Depth::new(0), Duration::ZERO, 0, pv)
     }
 }

--- a/lib/search/score.rs
+++ b/lib/search/score.rs
@@ -44,6 +44,12 @@ impl Score {
         assert!(Value::MIN + 2 * (Ply::MIN as i16 - 1) >= Self::MIN);
     };
 
+    /// The drawn score.
+    #[inline(always)]
+    pub fn drawn() -> Self {
+        Self::new(0)
+    }
+
     /// The tablebase loss score at `ply`.
     #[inline(always)]
     pub fn losing(ply: Ply) -> Self {

--- a/lib/syzygy/wdl.rs
+++ b/lib/syzygy/wdl.rs
@@ -33,7 +33,7 @@ impl Wdl {
         match self {
             Wdl::Win => Score::winning(ply),
             Wdl::Loss => Score::losing(ply),
-            _ => Score::new(0),
+            _ => Score::drawn(),
         }
     }
 }


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 50000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each restart=on tc=1+0.01 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 1.47 +/- 2.45, nElo: 2.63 +/- 4.39
LOS: 88.01 %, DrawRatio: 48.46 %, PairsRatio: 1.03
Games: 24066, Wins: 6179, Losses: 6077, Draws: 11810, Points: 12084.0 (50.21 %)
Ptnml(0-2): [209, 2853, 5831, 2907, 233], WL/DD Ratio: 0.93
LLR: 2.90 (100.2%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```