### PR TITLE
Vary starting aspiration window by search depth

### DIFF
--- a/lib/params.rs
+++ b/lib/params.rs
@@ -296,7 +296,7 @@ params! {
     winning_rating_margin: [-20.491241],
     winning_rating_gain: [0.0, 1.6685247],
     winning_rating_scalar: [15.832105],
-    aw_baseline: [4.9224224],
+    aw_baseline: [2048., 512., 128., 32., 8., 4.9224224, 4.9224224, 4.9224224],
     aw_gamma: [1.4124817],
     aw_delta: [1.2470169],
     aw_fail_low_blend: [0.51431525],

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -897,14 +897,9 @@ impl<'a> Searcher<'a> {
         gen move {
             for depth in Depth::iter() {
                 let mut reduction = 0.;
-                let mut window = *Params::aw_baseline(0);
-                let (mut lower, mut upper) = match depth.get() {
-                    ..=4 => (Score::lower(), Score::upper()),
-                    _ => (
-                        self.stack.pv.score() - window.to_int::<i16>(),
-                        self.stack.pv.score() + window.to_int::<i16>(),
-                    ),
-                };
+                let mut window = *Params::aw_baseline(depth.cast::<usize>().min(7));
+                let mut lower = self.stack.pv.score() - window.to_int::<i16>();
+                let mut upper = self.stack.pv.score() + window.to_int::<i16>();
 
                 loop {
                     let draft = depth - reduction.to_int::<i8>();


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=0 elo1=3 alpha=0.05 beta=0.10 -games 2 -rounds 50000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each restart=on tc=1+0.01 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 1.55 +/- 1.26, nElo: 2.77 +/- 2.25
LOS: 99.21 %, DrawRatio: 47.69 %, PairsRatio: 1.03
Games: 91778, Wins: 23887, Losses: 23477, Draws: 44414, Points: 46094.0 (50.22 %)
Ptnml(0-2): [761, 11087, 21886, 11291, 864], WL/DD Ratio: 0.99
LLR: 2.89 (100.0%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```