### PR TITLE
Increase correction history buckets to back to 16384

### DIFF
--- a/lib/search/correction.rs
+++ b/lib/search/correction.rs
@@ -4,7 +4,7 @@ use crate::util::Int;
 use bytemuck::{Zeroable, zeroed};
 use derive_more::with_trait::Debug;
 
-const BUCKETS: usize = 8192;
+const BUCKETS: usize = 16384;
 
 /// Historical statistics about a [`Move`](`crate::chess::Move`).
 #[derive(Debug, Clone, Hash, Zeroable)]


### PR DESCRIPTION
> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 50000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -draw movenumber=32 movecount=6 score=15 -resign movecount=5 score=600 -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=8+0.08 option.SyzygyPath=/tmp/engines/syzygy/ option.Hash=64`

```
--------------------------------------------------
Results of dev vs base (8+0.08, 1t, 64MB, UHO_Lichess_4852_v1.epd):
Elo: 1.25 +/- 2.06, nElo: 2.47 +/- 4.07
LOS: 88.29 %, DrawRatio: 50.87 %, PairsRatio: 1.03
Games: 28030, Wins: 6960, Losses: 6859, Draws: 14211, Points: 14065.5 (50.18 %)
Ptnml(0-2): [51, 3344, 7130, 3433, 57], WL/DD Ratio: 0.92
LLR: 3.22 (111.5%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```