### PR TITLE
Normalize scores based on a WDL model

### DIFF
--- a/lib/uci.rs
+++ b/lib/uci.rs
@@ -97,8 +97,11 @@ impl Display for UciSearchInfo {
         write!(f, " nodes {}", self.0.nodes())?;
         write!(f, " nps {}", self.0.nps() as u64)?;
 
+        const NORMALIZE_TO_PAWN_VALUE: i32 = 68;
+        let normalized_score = self.0.score().cast::<i32>() * 100 / NORMALIZE_TO_PAWN_VALUE;
+
         match self.0.score().mate() {
-            Mate::None => write!(f, " score cp {}", self.0.score())?,
+            Mate::None => write!(f, " score cp {}", normalized_score)?,
             Mate::Mating(p) => write!(f, " score mate {}", (p + 1) / 2)?,
             Mate::Mated(p) => write!(f, " score mate -{}", (p + 1) / 2)?,
         }


### PR DESCRIPTION
python scoreWDL.py --NormalizeToPawnValue 100
Converting evals with NormalizeToPawnValue = 100.
Reading eval stats from scoreWDLstat.json.
Retained (W,D,L) = (105601, 247792, 107839) positions. Fit WDL model based on material.
Initial objective function:  0.4306547262597904
Final objective function:    0.430638026259721
Optimization terminated successfully.
const int NormalizeToPawnValue = 68;
Corresponding spread = 19;
Corresponding normalized spread = 0.2763297321533774;
Draw rate at 0.0 eval at material 58 = 0.9477741529967769;
Parameters in internal value units:
p_a = ((-114.518 * x / 58 + 320.986) * x / 58 + -322.727) * x / 58 + 184.439
p_b = ((-33.940 * x / 58 + 112.684) * x / 58 + -118.016) * x / 58 + 58.111
    constexpr double as[] = {-114.51806163, 320.98591161, -322.72711779, 184.43949532};
    constexpr double bs[] = {-33.93956010, 112.68438244, -118.01585424, 58.11125591};