### PR TITLE
Move initialization of ZobristNumbers to compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default-run = "cinder"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
 
 [features]
-spsa = ["rand/thread_rng", "dep:ron", "dep:serde"]
+spsa = ["dep:rand", "dep:ron", "dep:serde"]
 trainer = ["dep:bullet"]
 no_panic = ["dep:no-panic"]
 
@@ -53,13 +53,13 @@ futures = { version = "0.3.31", default-features = false, features = [
 libc = { version = "0.2.178", default-features = false, features = ["std"] }
 memmap2 = { version = "0.9.9", default-features = false }
 nom = { version = "8.0.0", default-features = false, features = ["std"] }
-rand = { version = "0.9.2", default-features = false, features = [
-    "small_rng",
-    "std",
-] }
 rustc-hash = { version = "2.1.1", default-features = false, features = ["std"] }
 
 # spsa
+rand = { version = "0.9.2", optional = true, default-features = false, features = [
+    "std",
+    "thread_rng",
+] }
 ron = { version = "0.12.0", optional = true, default-features = false, features = [
     "std",
 ] }

--- a/bin/cinder.rs
+++ b/bin/cinder.rs
@@ -1,3 +1,5 @@
+#![allow(long_running_const_eval)]
+
 use anyhow::Error as Failure;
 use cinder::{uci::Uci, util::thread};
 use clap::Parser;

--- a/bin/spsa.rs
+++ b/bin/spsa.rs
@@ -1,3 +1,4 @@
+#![allow(long_running_const_eval)]
 #![feature(exit_status_error)]
 
 use anyhow::{Context, Error as Failure};

--- a/bin/trainer.rs
+++ b/bin/trainer.rs
@@ -1,3 +1,5 @@
+#![allow(long_running_const_eval)]
+
 use anyhow::{Context, Error as Failure};
 use bullet::game::formats::bulletformat::ChessBoard;
 use bullet::game::formats::sfbinpack::TrainingDataEntry;

--- a/tests/syzygy.rs
+++ b/tests/syzygy.rs
@@ -1,3 +1,5 @@
+#![allow(long_running_const_eval)]
+
 use cinder::syzygy::{Dtz, Syzygy, Wdl};
 use cinder::{chess::Position, search::Ply, util::Int};
 use proptest::sample::select;


### PR DESCRIPTION
### SPRT

> `fastchess -sprt elo0=-3 elo1=1 alpha=0.05 beta=0.10 -games 2 -rounds 50000 -openings file=/tmp/engines/openings/UHO_Lichess_4852_v1.epd order=random -tb /tmp/engines/syzygy/ -draw movenumber=32 movecount=6 score=15 -resign movecount=5 score=600 -concurrency 16 -use-affinity -recover -engine name=dev cmd=/tmp/engines/dev -engine name=base cmd=/tmp/engines/base -each tc=1+0.01 option.SyzygyPath=/tmp/engines/syzygy/`

```
--------------------------------------------------
Results of dev vs base (1+0.01, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 0.75 +/- 1.98, nElo: 1.34 +/- 3.52
LOS: 77.16 %, DrawRatio: 47.28 %, PairsRatio: 1.02
Games: 37434, Wins: 9589, Losses: 9508, Draws: 18337, Points: 18757.5 (50.11 %)
Ptnml(0-2): [326, 4571, 8849, 4638, 333], WL/DD Ratio: 0.94
LLR: 2.90 (100.3%) (-2.25, 2.89) [-3.00, 1.00]
--------------------------------------------------
```